### PR TITLE
Исправление сборки и публикации установщиков в GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,7 +30,7 @@ jobs:
         run: npm install
 
       - name: Build and Release
-        run: npm run package
+        run: npm run package -- --publish always
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -38,4 +38,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: build-artifacts-${{ matrix.os }}
-          path: release/1.0.0/
+          path: release/**

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yetanothersshclient-ts",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yetanothersshclient-ts",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@xterm/addon-clipboard": "^0.2.0",
         "@xterm/addon-fit": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -50,6 +50,9 @@
     "directories": {
       "output": "release/${version}"
     },
+    "publish": [
+      "github"
+    ],
     "files": [
       "dist",
       "dist-electron"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -854,7 +854,7 @@ function App() {
                                             <br/>
                                             <b style={{fontSize: '1.5em'}}>YetAnotherSSHClient</b>
                                             <br/><br/>
-                                            Версия: 1.0.0
+                                            Версия: 1.0.1
                                             <br/><br/>
                                             GitHub: <a href="#" onClick={(e) => {
                                             e.preventDefault();


### PR DESCRIPTION
Я исправил проблему с созданием установщиков в GitHub Actions. Основные изменения:
1. Синхронизировал версию приложения (1.0.1) во всех файлах (`package.json`, `package-lock.json`, `src/App.tsx`), чтобы `electron-builder` корректно именовал файлы.
2. Обновил конфигурацию `electron-builder` в `package.json`, добавив параметр `"publish": ["github"]`.
3. Исправил `.github/workflows/build.yml`: теперь артефакты ищутся по маске `release/**` (вместо жестко прописанной старой версии), а команда сборки включает флаг `--publish always` для автоматической загрузки файлов в GitHub Releases.
4. Проверил сборку проекта командой `npm run build`.

Теперь после пуша в GitHub Actions будут создаваться и публиковаться файлы .exe, .dmg, .deb и .AppImage.

---
*PR created automatically by Jules for task [14119141454430511686](https://jules.google.com/task/14119141454430511686) started by @megoRU*