### PR TITLE
Fix CI build failures on Windows and Linux by upgrading Node.js version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Install dependencies

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,9 @@
         "vite": "^7.3.1",
         "vite-plugin-electron": "^0.29.0",
         "vite-plugin-electron-renderer": "^0.14.6"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "version": "1.0.3",
   "description": "A modern multi-platform SSH client built with React and Electron",
   "author": "YetAnotherSSHClient Team <support@yash.client>",
+  "engines": {
+    "node": ">=22.12.0"
+  },
   "type": "module",
   "main": "dist-electron/main.js",
   "scripts": {


### PR DESCRIPTION
Updated Node.js version in `.github/workflows/build.yml` from 20 to 22 to satisfy dependency requirements (`@electron/rebuild` and `node-abi`). Added `engines` field to `package.json` to enforce Node.js >= 22.12.0. Verified with `npm run lint`.

---
*PR created automatically by Jules for task [4872015621091152789](https://jules.google.com/task/4872015621091152789) started by @megoRU*