### PR TITLE
Fix unwanted window resizing on startup and settings save

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -89,27 +89,46 @@ function createWindow(): void {
     const saveWindowState = () => {
         if (saveTimeout) clearTimeout(saveTimeout)
         saveTimeout = setTimeout(() => {
-            if (!mainWindow) return
+            if (!mainWindow || mainWindow.isDestroyed()) return
             const isMaximized = mainWindow.isMaximized()
             const bounds = isMaximized ? mainWindow.getNormalBounds() : mainWindow.getBounds()
             const current = loadConfig()
 
-            current.x = Math.round(bounds.x)
-            current.y = Math.round(bounds.y)
-            current.width = Math.round(bounds.width)
-            current.height = Math.round(bounds.height)
+            const x = Math.round(bounds.x)
+            const y = Math.round(bounds.y)
+            const width = Math.round(bounds.width)
+            const height = Math.round(bounds.height)
+
+            // Проверяем, изменились ли параметры, чтобы избежать лишних записей на диск
+            if (current.x === x &&
+                current.y === y &&
+                current.width === width &&
+                current.height === height &&
+                current.maximized === isMaximized) {
+                return
+            }
+
+            current.x = x
+            current.y = y
+            current.width = width
+            current.height = height
             current.maximized = isMaximized
 
             saveConfig(current)
         }, 500)
     }
 
-    mainWindow.on('resize', saveWindowState)
-    mainWindow.on('move', saveWindowState)
-    mainWindow.on('maximize', saveWindowState)
-    mainWindow.on('unmaximize', saveWindowState)
-
-    mainWindow.once('ready-to-show', () => mainWindow?.show())
+    mainWindow.once('ready-to-show', () => {
+        mainWindow?.show()
+        // Навешиваем слушатели после того, как окно показано и стабилизировано
+        setTimeout(() => {
+            if (!mainWindow || mainWindow.isDestroyed()) return
+            mainWindow.on('resize', saveWindowState)
+            mainWindow.on('move', saveWindowState)
+            mainWindow.on('maximize', saveWindowState)
+            mainWindow.on('unmaximize', saveWindowState)
+        }, 1000)
+    })
 
     const themeParam = `?theme=${encodeURIComponent(config.theme)}`
     if (process.env.VITE_DEV_SERVER_URL) {

--- a/electron/src/config.ts
+++ b/electron/src/config.ts
@@ -22,6 +22,8 @@ export const DEFAULT_CONFIG: AppConfig = {
     lastUpdateCheck: 0
 }
 
+let cachedConfig: AppConfig | null = null
+
 /**
  * Загружает конфигурацию из файла.
  * Если файл не существует или поврежден, возвращает конфигурацию по умолчанию.
@@ -29,12 +31,22 @@ export const DEFAULT_CONFIG: AppConfig = {
  * @returns {AppConfig} Объект конфигурации приложения.
  */
 export function loadConfig(): AppConfig {
-    if (!fs.existsSync(configPath)) return DEFAULT_CONFIG
-    try {
-        return JSON.parse(fs.readFileSync(configPath, 'utf-8')) as AppConfig
-    } catch {
-        return DEFAULT_CONFIG
+    if (cachedConfig) return cachedConfig
+
+    let config: AppConfig
+    if (!fs.existsSync(configPath)) {
+        config = { ...DEFAULT_CONFIG }
+    } else {
+        try {
+            const data = JSON.parse(fs.readFileSync(configPath, 'utf-8'))
+            config = { ...DEFAULT_CONFIG, ...data }
+        } catch {
+            config = { ...DEFAULT_CONFIG }
+        }
     }
+
+    cachedConfig = config
+    return config
 }
 
 /**
@@ -43,5 +55,6 @@ export function loadConfig(): AppConfig {
  * @param {AppConfig} config - Объект конфигурации для сохранения.
  */
 export function saveConfig(config: AppConfig): void {
+    cachedConfig = config
     fs.writeFileSync(configPath, JSON.stringify(config, null, 2))
 }

--- a/electron/src/ipc-handlers.ts
+++ b/electron/src/ipc-handlers.ts
@@ -15,7 +15,19 @@ import { AppConfig, SshConnectPayload } from './types.js'
 export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
     // Конфигурация
     ipcMain.handle('get-config', () => loadConfig())
-    ipcMain.handle('save-config', (_, config: AppConfig) => saveConfig(config))
+    ipcMain.handle('save-config', (_, config: AppConfig) => {
+        const win = getMainWindow()
+        if (win) {
+            const isMaximized = win.isMaximized()
+            const bounds = isMaximized ? win.getNormalBounds() : win.getBounds()
+            config.x = Math.round(bounds.x)
+            config.y = Math.round(bounds.y)
+            config.width = Math.round(bounds.width)
+            config.height = Math.round(bounds.height)
+            config.maximized = isMaximized
+        }
+        saveConfig(config)
+    })
 
     // Системные ресурсы
     ipcMain.handle('get-system-fonts', () => getSystemFonts())

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yetanothersshclient",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yetanothersshclient",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "dependencies": {
         "@xterm/addon-clipboard": "^0.2.0",
         "@xterm/addon-fit": "^0.11.0",


### PR DESCRIPTION
This change fixes the issue where the application window would sometimes change its size or position automatically upon startup or when saving settings, even if no manual resizing was performed.

Key improvements:
1.  **Event Silencing on Startup**: Window `resize` and `move` listeners are now attached with a 1-second delay after the window is shown, effectively ignoring initial "noisy" events emitted by the OS during window placement.
2.  **Robust Equality Checks**: The state-saving logic now compares current window bounds against the stored configuration (using `Math.round` for DPI-awareness) and only writes to disk if a meaningful change is detected.
3.  **IPC State Synchronization**: The `save-config` handler in the main process now captures and injects the window's actual dimensions into configuration updates received from the renderer, preventing accidental overwrites from the frontend.
4.  **In-Memory Caching**: Added a `cachedConfig` in the main process to ensure consistency and improve performance by reducing disk reads.

---
*PR created automatically by Jules for task [7434120776733576624](https://jules.google.com/task/7434120776733576624) started by @megoRU*