### PR TITLE
Disable WebGL for macOS x86

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -13,8 +13,14 @@ import { registerIpcHandlers } from './src/ipc-handlers.js'
 app.commandLine.appendSwitch('disable-renderer-backgrounding')
 app.commandLine.appendSwitch('disable-background-timer-throttling')
 app.commandLine.appendSwitch('disable-backgrounding-occluded-windows')
-app.commandLine.appendSwitch('ignore-gpu-blacklist')
-app.commandLine.appendSwitch('enable-gpu-rasterization')
+
+if (process.platform === 'darwin' && process.arch === 'x64') {
+    app.commandLine.appendSwitch('disable-webgl')
+} else {
+    app.commandLine.appendSwitch('ignore-gpu-blacklist')
+    app.commandLine.appendSwitch('enable-gpu-rasterization')
+}
+
 app.commandLine.appendSwitch('enable-zero-copy')
 
 /* ================= ERRORS ================= */

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -10,4 +10,5 @@ contextBridge.exposeInMainWorld('ipcRenderer', {
   invoke: (channel: string, data: unknown) => ipcRenderer.invoke(channel, data),
   removeAllListeners: (channel: string) => ipcRenderer.removeAllListeners(channel),
   platform: process.platform,
+  arch: process.arch,
 })

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -185,11 +185,16 @@ export const TerminalComponent: React.FC<Props> = ({
         term.loadAddon(clipboardAddon);
         term.open(termRef.current);
 
-        try {
-            const webglAddon = new WebglAddon();
-            term.loadAddon(webglAddon);
-        } catch (e) {
-            console.warn('WebGL addon could not be loaded, falling back to standard renderer', e);
+        const isMacX86 = ipcRenderer.platform === 'darwin' && ipcRenderer.arch === 'x64';
+        if (!isMacX86) {
+            try {
+                const webglAddon = new WebglAddon();
+                term.loadAddon(webglAddon);
+            } catch (e) {
+                console.warn('WebGL addon could not be loaded, falling back to standard renderer', e);
+            }
+        } else {
+            console.log('WebGL disabled for macOS x86');
         }
 
         xtermRef.current = term;


### PR DESCRIPTION
This change disables WebGL for macOS systems running on x86 (Intel) architecture while keeping it enabled for all other platforms and architectures (including macOS ARM).

Key changes:
1. **Preload Script**: Added `arch: process.arch` to the exposed `ipcRenderer` object so the renderer process can identify the system architecture.
2. **Terminal Component**: Updated the `TerminalComponent` to check for macOS x86. If detected, it skips loading the `WebglAddon` to prevent performance issues or crashes on older Intel Macs.
3. **Main Process**: Added a condition in the performance optimization section. For macOS x86, it appends the `disable-webgl` command line switch and omits `ignore-gpu-blacklist` and `enable-gpu-rasterization` flags. For all other systems, it maintains the original GPU optimization flags.

---
*PR created automatically by Jules for task [6823648359954169743](https://jules.google.com/task/6823648359954169743) started by @megoRU*