### PR TITLE
sFTP: Prompt to upload file on save

### DIFF
--- a/electron/src/ipc-handlers.ts
+++ b/electron/src/ipc-handlers.ts
@@ -548,7 +548,9 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
         if (!sftp) return null
 
         const tmpDir = app.getPath('temp')
-        const localPath = path.join(tmpDir, `yash_${Date.now()}_${filename}`)
+        const fileDir = path.join(tmpDir, `yash_${Date.now()}`)
+        if (!fs.existsSync(fileDir)) fs.mkdirSync(fileDir, { recursive: true })
+        const localPath = path.join(fileDir, filename)
 
         await new Promise((resolve, reject) => {
             sftp.fastGet(remotePath, localPath, (err) => {

--- a/electron/src/ipc-handlers.ts
+++ b/electron/src/ipc-handlers.ts
@@ -5,7 +5,7 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { loadConfig, saveConfig } from './config.js'
 import { getSystemFonts } from './font-service.js'
-import { sshClients, shellStreams, sshSockets, sftpClients, cleanupConnection, cleanupAll } from './ssh-manager.js'
+import { sshClients, shellStreams, sshSockets, sftpClients, sftpWatchers, cleanupConnection, cleanupAll } from './ssh-manager.js'
 import { AppConfig, SshConnectPayload, SftpConnectPayload } from './types.js'
 
 /**
@@ -557,8 +557,50 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
             })
         })
 
+        // Setup file watcher
+        let debounceTimer: NodeJS.Timeout | null = null
+        const watcher = fs.watch(localPath, (eventType) => {
+            if (eventType === 'change') {
+                if (debounceTimer) clearTimeout(debounceTimer)
+                debounceTimer = setTimeout(() => {
+                    const win = getMainWindow()
+                    if (win) {
+                        win.webContents.send(`sftp-file-changed-${id}`, {
+                            localPath,
+                            remotePath,
+                            filename
+                        })
+                    }
+                }, 500)
+            }
+        })
+
+        if (!sftpWatchers.has(id)) {
+            sftpWatchers.set(id, new Map())
+        }
+        sftpWatchers.get(id)!.set(localPath, watcher)
+
         await shell.openPath(localPath)
         return true
+    })
+
+    ipcMain.handle('sftp-upload-direct', async (_, payload: { id: string; localPath: string; remotePath: string }) => {
+        const { id, localPath, remotePath } = payload
+        const sftp = sftpClients.get(id)
+        if (!sftp) throw new Error('SFTP client not found')
+
+        return new Promise((resolve, reject) => {
+            sftp.fastPut(localPath, remotePath, (err) => {
+                if (err) reject(err)
+                else {
+                    const win = getMainWindow()
+                    if (win) {
+                        win.webContents.send(`sftp-progress-${id}`, { remotePath, progress: 100, type: 'upload' })
+                    }
+                    resolve(true)
+                }
+            })
+        })
     })
 
     ipcMain.handle('sftp-rm', async (_, payload: { id: string; path: string; isDir: boolean }) => {

--- a/electron/src/ssh-manager.ts
+++ b/electron/src/ssh-manager.ts
@@ -1,5 +1,6 @@
 import { Client, type ClientChannel, type SFTPWrapper } from 'ssh2'
 import * as net from 'node:net'
+import * as fs from 'node:fs'
 
 /** Хранилище активных SSH-клиентов по ID сессии */
 export const sshClients = new Map<string, Client>()
@@ -13,12 +14,22 @@ export const sftpClients = new Map<string, SFTPWrapper>()
 /** Хранилище TCP-сокетов для SSH-соединений по ID сессии */
 export const sshSockets = new Map<string, net.Socket>()
 
+/** Хранилище активных вотчеров за файлами по ID сессии и локальному пути */
+export const sftpWatchers = new Map<string, Map<string, fs.FSWatcher>>()
+
 /**
  * Закрывает и удаляет конкретное SSH-соединение по его ID.
  *
  * @param {string} id - Уникальный идентификатор сессии.
  */
 export function cleanupConnection(id: string): void {
+    // Очистка вотчеров
+    const watchers = sftpWatchers.get(id)
+    if (watchers) {
+        watchers.forEach(w => w.close())
+        sftpWatchers.delete(id)
+    }
+
     sftpClients.get(id)?.end()
     shellStreams.get(id)?.destroy()
     sshClients.get(id)?.destroy()
@@ -34,6 +45,9 @@ export function cleanupConnection(id: string): void {
  * Используется при выходе из приложения.
  */
 export function cleanupAll(): void {
+    sftpWatchers.forEach(watchers => watchers.forEach(w => w.close()))
+    sftpWatchers.clear()
+
     sftpClients.forEach(s => s.end())
     shellStreams.forEach(s => s.destroy())
     sshClients.forEach(c => c.destroy())

--- a/src/components/SFTPBrowser.tsx
+++ b/src/components/SFTPBrowser.tsx
@@ -63,7 +63,7 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible}) => {
     const [contextMenu, setContextMenu] = useState<{ x: number, y: number, file?: FileEntry } | null>(null);
 
     // Modal states
-    const [modal, setModal] = useState<{ type: 'delete' | 'rename' | 'permissions' | 'error' | 'cancelUpload', file?: FileEntry, errorMessage?: string, cancelPath?: string } | null>(null);
+    const [modal, setModal] = useState<{ type: 'delete' | 'rename' | 'permissions' | 'error' | 'cancelUpload' | 'fileUpdate', file?: FileEntry, errorMessage?: string, cancelPath?: string, localPath?: string, remotePath?: string, filename?: string } | null>(null);
     const [modalInput, setModalInput] = useState('');
 
     const isConnectingRef = useRef(false);
@@ -177,6 +177,15 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible}) => {
             isConnectingRef.current = false;
         });
 
+        const unsubFileChanged = ipcRenderer.on(`sftp-file-changed-${id}`, (data: { localPath: string, remotePath: string, filename: string }) => {
+            setModal({
+                type: 'fileUpdate',
+                localPath: data.localPath,
+                remotePath: data.remotePath,
+                filename: data.filename
+            });
+        });
+
         const unsubProgress = ipcRenderer.on(`sftp-progress-${id}`, (data: Progress) => {
             setActiveTransfers(prev => {
                 const normalizedPath = normalizeRemotePath(data.remotePath);
@@ -223,6 +232,7 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible}) => {
             if (typeof unsubStatus === 'function') unsubStatus();
             if (typeof unsubError === 'function') unsubError();
             if (typeof unsubProgress === 'function') unsubProgress();
+            if (typeof unsubFileChanged === 'function') unsubFileChanged();
             ipcRenderer.send('ssh-close', id);
         };
     }, [id]);
@@ -351,6 +361,21 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible}) => {
             loadDirectory(path);
         } catch (err: any) {
             showError(`Ошибка изменения прав: ${err.message}`);
+        }
+    };
+
+    const handleUpdateFromServer = async () => {
+        if (!modal || modal.type !== 'fileUpdate' || !modal.localPath || !modal.remotePath) return;
+        try {
+            await ipcRenderer.invoke('sftp-upload-direct', {
+                id,
+                localPath: modal.localPath,
+                remotePath: modal.remotePath
+            });
+            setModal(null);
+            loadDirectory(path);
+        } catch (err: any) {
+            showError(`Ошибка обновления файла: ${err.message}`);
         }
     };
 
@@ -945,11 +970,16 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible}) => {
                                 {modal.type === 'permissions' && 'Права доступа'}
                                 {modal.type === 'error' && 'Ошибка'}
                                 {modal.type === 'cancelUpload' && 'Отмена загрузки'}
+                                {modal.type === 'fileUpdate' && 'Обновление файла'}
                             </h3>
                         </div>
 
                         {modal.type === 'delete' && (
                             <p>Вы уверены, что хотите удалить <b>{selectedFilenames.length > 1 ? `${selectedFilenames.length} элементов` : modal.file?.filename}</b>?</p>
+                        )}
+
+                        {modal.type === 'fileUpdate' && (
+                            <p>Файл <b>{modal.filename}</b> был изменен. Обновить его на сервере?</p>
                         )}
 
                         {modal.type === 'error' && (
@@ -988,9 +1018,10 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible}) => {
                                     else if (modal.type === 'permissions') handlePermissions();
                                     else if (modal.type === 'error') setModal(null);
                                     else if (modal.type === 'cancelUpload') handleCancelUpload();
+                                    else if (modal.type === 'fileUpdate') handleUpdateFromServer();
                                 }}
                             >
-                                {modal.type === 'delete' ? 'Удалить' : modal.type === 'error' ? 'OK' : modal.type === 'cancelUpload' ? 'Да, отменить' : 'Сохранить'}
+                                {modal.type === 'delete' ? 'Удалить' : modal.type === 'error' ? 'OK' : modal.type === 'cancelUpload' ? 'Да, отменить' : modal.type === 'fileUpdate' ? 'Обновить' : 'Сохранить'}
                             </button>
                         </div>
                     </div>


### PR DESCRIPTION
This change adds a "save-to-sync" feature for the sFTP browser. When a file is opened in an external editor from the sFTP browser, the application now monitors the local temporary file for changes. When a save is detected, the user is prompted with a confirmation dialog to upload the modified file back to the remote server.

Key changes:
1.  **Backend (Electron):**
    -   `ssh-manager.ts`: Added state management for file watchers and updated cleanup logic to prevent resource leaks.
    -   `ipc-handlers.ts`: Enhanced `sftp-open-in-editor` to start watching the downloaded file. Added a new `sftp-upload-direct` handler for the actual update.
2.  **Frontend (React):**
    -   `SFTPBrowser.tsx`: Added an IPC listener for file change events. When a change is detected, a new modal type (`fileUpdate`) is displayed, asking the user if they want to update the file on the server.
3.  **Localization:** All user-facing strings for the new feature are in Russian.
4.  **Reliability:** Included a 500ms debounce for file system events to handle editors that perform multiple writes.

---
*PR created automatically by Jules for task [12926648793035922275](https://jules.google.com/task/12926648793035922275) started by @megoRU*