### PR TITLE
Fix duplicate terminal paste via keyboard shortcuts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yetanothersshclient",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yetanothersshclient",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "@xterm/addon-clipboard": "^0.2.0",
         "@xterm/addon-fit": "^0.11.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yetanothersshclient",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yetanothersshclient",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "dependencies": {
         "@xterm/addon-clipboard": "^0.2.0",
         "@xterm/addon-fit": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yetanothersshclient",
   "private": true,
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A modern multi-platform SSH client built with React and Electron",
   "author": "YetAnotherSSHClient Team <support@yash.client>",
   "engines": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -896,7 +896,7 @@ function App() {
                                             <br/>
                                             <b style={{fontSize: '1.5em'}}>YetAnotherSSHClient</b>
                                             <br/><br/>
-                                            Версия: 1.1.1
+                                            Версия: 1.1.2
                                             <br/><br/>
                                             GitHub: <a href="#" onClick={(e) => {
                                             e.preventDefault();

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -217,6 +217,8 @@ export const TerminalComponent: React.FC<Props> = ({
                 const isPaste = (isMac && e.metaKey && e.code === 'KeyV') || (e.ctrlKey && e.shiftKey && e.code === 'KeyV');
 
                 if (isCopy) {
+                    e.preventDefault();
+                    e.stopPropagation();
                     const selection = term.getSelection();
                     if (selection) {
                         navigator.clipboard.writeText(selection);
@@ -225,8 +227,12 @@ export const TerminalComponent: React.FC<Props> = ({
                 }
 
                 if (isPaste) {
+                    e.preventDefault();
+                    e.stopPropagation();
                     navigator.clipboard.readText().then(text => {
-                        ipcRenderer.send('ssh-input', { id: connId, data: text });
+                        if (text && isMountedRef.current) {
+                            term.paste(text);
+                        }
                     });
                     return false;
                 }


### PR DESCRIPTION
This PR fixes an issue where commands pasted into the terminal using keyboard shortcuts (Ctrl+Shift+V / Cmd+V) were being duplicated. 

The fix involves:
1. Stopping the default event propagation and default browser behavior for copy and paste shortcuts in the terminal's custom key event handler.
2. Switching the paste logic to use xterm.js's native `term.paste(text)` method. This ensures that the terminal's `onData` event is triggered normally, which in turn sends the data over the SSH connection via IPC, avoiding the double-send that occurred when both the default paste and a manual IPC send were active.
3. Adding a check to ensure the component is still mounted when the asynchronous clipboard `readText` promise resolves.

---
*PR created automatically by Jules for task [15908104859813610803](https://jules.google.com/task/15908104859813610803) started by @megoRU*