### PR TITLE
Fix connection issues to routers and legacy hardware

### DIFF
--- a/electron/src/ipc-handlers.ts
+++ b/electron/src/ipc-handlers.ts
@@ -71,7 +71,7 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
             const connectConfig: ConnectConfig = {
                 sock: socket,
                 username: config.user,
-                readyTimeout: 30000,
+                readyTimeout: 30000, // Увеличиваем до 30с для медленных устройств
                 keepaliveInterval: 10000,
                 keepaliveCountMax: 3
             }
@@ -79,12 +79,52 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
             if (config.allowLegacyAlgorithms) {
                 connectConfig.tryKeyboard = true
                 connectConfig.ident = 'OpenSSH_8.2p1'
-                connectConfig.preferredAuthentications = ['password', 'keyboard-interactive', 'publickey']
+                // Приоритет методам в зависимости от типа аутентификации
+                connectConfig.preferredAuthentications = config.authType === 'key'
+                    ? ['publickey', 'password', 'keyboard-interactive']
+                    : ['password', 'keyboard-interactive', 'publickey']
+
                 connectConfig.algorithms = {
-                    kex: ['diffie-hellman-group1-sha1', 'diffie-hellman-group14-sha1', 'diffie-hellman-group-exchange-sha1', 'diffie-hellman-group-exchange-sha256', 'curve25519-sha256', 'curve25519-sha256@libssh.org', 'ecdh-sha2-nistp256', 'ecdh-sha2-nistp384', 'ecdh-sha2-nistp521'],
-                    cipher: ['aes128-cbc', '3des-cbc', 'aes192-cbc', 'aes256-cbc', 'blowfish-cbc', 'cast128-cbc', 'arcfour', 'aes128-ctr', 'aes192-ctr', 'aes256-ctr', 'aes128-gcm', 'aes128-gcm@openssh.com', 'aes256-gcm', 'aes256-gcm@openssh.com'],
-                    hmac: ['hmac-sha1', 'hmac-sha1-96', 'hmac-md5', 'hmac-md5-96', 'hmac-sha2-256', 'hmac-sha2-512'],
-                    serverHostKey: ['ssh-rsa', 'ssh-dss', 'ssh-ed25519', 'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521', 'rsa-sha2-512', 'rsa-sha2-256']
+                    kex: [
+                        'diffie-hellman-group1-sha1',
+                        'diffie-hellman-group14-sha1',
+                        'diffie-hellman-group-exchange-sha1',
+                        'diffie-hellman-group-exchange-sha256',
+                        'curve25519-sha256',
+                        'curve25519-sha256@libssh.org',
+                        'ecdh-sha2-nistp256',
+                        'ecdh-sha2-nistp384',
+                        'ecdh-sha2-nistp521'
+                    ],
+                    cipher: [
+                        'aes128-cbc',
+                        '3des-cbc',
+                        'aes192-cbc',
+                        'aes256-cbc',
+                        'aes128-ctr',
+                        'aes192-ctr',
+                        'aes256-ctr',
+                        'aes128-gcm',
+                        'aes128-gcm@openssh.com',
+                        'aes256-gcm',
+                        'aes256-gcm@openssh.com'
+                    ],
+                    hmac: [
+                        'hmac-sha1',
+                        'hmac-sha1-96',
+                        'hmac-sha2-256',
+                        'hmac-sha2-512'
+                    ],
+                    serverHostKey: [
+                        'ssh-rsa',
+                        'ssh-dss',
+                        'ssh-ed25519',
+                        'ecdsa-sha2-nistp256',
+                        'ecdsa-sha2-nistp384',
+                        'ecdsa-sha2-nistp521',
+                        'rsa-sha2-512',
+                        'rsa-sha2-256'
+                    ]
                 }
             }
 
@@ -103,7 +143,12 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
 
             sshClient.on('keyboard-interactive', (name, instructions, instructionsLang, prompts, finish) => {
                 const password = Buffer.from(config.password ?? '', 'base64').toString('utf8')
-                finish(Array(prompts.length).fill(password))
+                const responses = prompts.map(p => {
+                    const pr = p.prompt.toLowerCase()
+                    if (pr.includes('user') || pr.includes('login')) return config.user
+                    return password
+                })
+                finish(responses)
             })
 
             sshClient.connect(connectConfig)
@@ -217,12 +262,51 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
             if (config.allowLegacyAlgorithms) {
                 connectConfig.tryKeyboard = true
                 connectConfig.ident = 'OpenSSH_8.2p1'
-                connectConfig.preferredAuthentications = ['password', 'keyboard-interactive', 'publickey']
+                connectConfig.preferredAuthentications = config.authType === 'key'
+                    ? ['publickey', 'password', 'keyboard-interactive']
+                    : ['password', 'keyboard-interactive', 'publickey']
+
                 connectConfig.algorithms = {
-                    kex: ['diffie-hellman-group1-sha1', 'diffie-hellman-group14-sha1', 'diffie-hellman-group-exchange-sha1', 'diffie-hellman-group-exchange-sha256', 'curve25519-sha256', 'curve25519-sha256@libssh.org', 'ecdh-sha2-nistp256', 'ecdh-sha2-nistp384', 'ecdh-sha2-nistp521'],
-                    cipher: ['aes128-cbc', '3des-cbc', 'aes192-cbc', 'aes256-cbc', 'blowfish-cbc', 'cast128-cbc', 'arcfour', 'aes128-ctr', 'aes192-ctr', 'aes256-ctr', 'aes128-gcm', 'aes128-gcm@openssh.com', 'aes256-gcm', 'aes256-gcm@openssh.com'],
-                    hmac: ['hmac-sha1', 'hmac-sha1-96', 'hmac-md5', 'hmac-md5-96', 'hmac-sha2-256', 'hmac-sha2-512'],
-                    serverHostKey: ['ssh-rsa', 'ssh-dss', 'ssh-ed25519', 'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521', 'rsa-sha2-512', 'rsa-sha2-256']
+                    kex: [
+                        'diffie-hellman-group1-sha1',
+                        'diffie-hellman-group14-sha1',
+                        'diffie-hellman-group-exchange-sha1',
+                        'diffie-hellman-group-exchange-sha256',
+                        'curve25519-sha256',
+                        'curve25519-sha256@libssh.org',
+                        'ecdh-sha2-nistp256',
+                        'ecdh-sha2-nistp384',
+                        'ecdh-sha2-nistp521'
+                    ],
+                    cipher: [
+                        'aes128-cbc',
+                        '3des-cbc',
+                        'aes192-cbc',
+                        'aes256-cbc',
+                        'aes128-ctr',
+                        'aes192-ctr',
+                        'aes256-ctr',
+                        'aes128-gcm',
+                        'aes128-gcm@openssh.com',
+                        'aes256-gcm',
+                        'aes256-gcm@openssh.com'
+                    ],
+                    hmac: [
+                        'hmac-sha1',
+                        'hmac-sha1-96',
+                        'hmac-sha2-256',
+                        'hmac-sha2-512'
+                    ],
+                    serverHostKey: [
+                        'ssh-rsa',
+                        'ssh-dss',
+                        'ssh-ed25519',
+                        'ecdsa-sha2-nistp256',
+                        'ecdsa-sha2-nistp384',
+                        'ecdsa-sha2-nistp521',
+                        'rsa-sha2-512',
+                        'rsa-sha2-256'
+                    ]
                 }
             }
 
@@ -241,7 +325,12 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
 
             sshClient.on('keyboard-interactive', (name, instructions, instructionsLang, prompts, finish) => {
                 const password = Buffer.from(config.password ?? '', 'base64').toString('utf8')
-                finish(Array(prompts.length).fill(password))
+                const responses = prompts.map(p => {
+                    const pr = p.prompt.toLowerCase()
+                    if (pr.includes('user') || pr.includes('login')) return config.user
+                    return password
+                })
+                finish(responses)
             })
 
             console.log(`[SFTP] Starting SSH handshake for ID: ${id}`)

--- a/electron/src/ipc-handlers.ts
+++ b/electron/src/ipc-handlers.ts
@@ -59,7 +59,7 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
         sshClients.set(id, sshClient)
 
         const socket = net.connect({
-            port: config.port || 22,
+            port: Number(config.port) || 22,
             host: config.host,
             timeout: 15000
         })
@@ -71,17 +71,20 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
             const connectConfig: ConnectConfig = {
                 sock: socket,
                 username: config.user,
-                readyTimeout: 20000,
+                readyTimeout: 30000,
                 keepaliveInterval: 10000,
                 keepaliveCountMax: 3
             }
 
             if (config.allowLegacyAlgorithms) {
+                connectConfig.tryKeyboard = true
+                connectConfig.ident = 'OpenSSH_8.2p1'
+                connectConfig.preferredAuthentications = ['password', 'keyboard-interactive', 'publickey']
                 connectConfig.algorithms = {
-                    kex: ['curve25519-sha256', 'curve25519-sha256@libssh.org', 'ecdh-sha2-nistp256', 'ecdh-sha2-nistp384', 'ecdh-sha2-nistp521', 'diffie-hellman-group-exchange-sha256', 'diffie-hellman-group14-sha1', 'diffie-hellman-group-exchange-sha1', 'diffie-hellman-group1-sha1'],
-                    cipher: ['aes128-ctr', 'aes192-ctr', 'aes256-ctr', 'aes128-gcm', 'aes128-gcm@openssh.com', 'aes256-gcm', 'aes256-gcm@openssh.com', 'aes128-cbc', '3des-cbc', 'aes192-cbc', 'aes256-cbc'],
-                    hmac: ['hmac-sha2-256', 'hmac-sha2-512', 'hmac-sha1', 'hmac-sha1-96'],
-                    serverHostKey: ['ssh-ed25519', 'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521', 'rsa-sha2-512', 'rsa-sha2-256', 'ssh-rsa', 'ssh-dss']
+                    kex: ['diffie-hellman-group1-sha1', 'diffie-hellman-group14-sha1', 'diffie-hellman-group-exchange-sha1', 'diffie-hellman-group-exchange-sha256', 'curve25519-sha256', 'curve25519-sha256@libssh.org', 'ecdh-sha2-nistp256', 'ecdh-sha2-nistp384', 'ecdh-sha2-nistp521'],
+                    cipher: ['aes128-cbc', '3des-cbc', 'aes192-cbc', 'aes256-cbc', 'blowfish-cbc', 'cast128-cbc', 'arcfour', 'aes128-ctr', 'aes192-ctr', 'aes256-ctr', 'aes128-gcm', 'aes128-gcm@openssh.com', 'aes256-gcm', 'aes256-gcm@openssh.com'],
+                    hmac: ['hmac-sha1', 'hmac-sha1-96', 'hmac-md5', 'hmac-md5-96', 'hmac-sha2-256', 'hmac-sha2-512'],
+                    serverHostKey: ['ssh-rsa', 'ssh-dss', 'ssh-ed25519', 'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521', 'rsa-sha2-512', 'rsa-sha2-256']
                 }
             }
 
@@ -97,6 +100,11 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
             } else {
                 connectConfig.password = Buffer.from(config.password ?? '', 'base64').toString('utf8')
             }
+
+            sshClient.on('keyboard-interactive', (name, instructions, instructionsLang, prompts, finish) => {
+                const password = Buffer.from(config.password ?? '', 'base64').toString('utf8')
+                finish(Array(prompts.length).fill(password))
+            })
 
             sshClient.connect(connectConfig)
         })
@@ -189,7 +197,7 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
         sshClients.set(id, sshClient)
 
         const socket = net.connect({
-            port: config.port || 22,
+            port: Number(config.port) || 22,
             host: config.host,
             timeout: 15000
         })
@@ -201,17 +209,20 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
             const connectConfig: ConnectConfig = {
                 sock: socket,
                 username: config.user,
-                readyTimeout: 20000,
+                readyTimeout: 30000,
                 keepaliveInterval: 10000,
                 keepaliveCountMax: 3
             }
 
             if (config.allowLegacyAlgorithms) {
+                connectConfig.tryKeyboard = true
+                connectConfig.ident = 'OpenSSH_8.2p1'
+                connectConfig.preferredAuthentications = ['password', 'keyboard-interactive', 'publickey']
                 connectConfig.algorithms = {
-                    kex: ['curve25519-sha256', 'curve25519-sha256@libssh.org', 'ecdh-sha2-nistp256', 'ecdh-sha2-nistp384', 'ecdh-sha2-nistp521', 'diffie-hellman-group-exchange-sha256', 'diffie-hellman-group14-sha1', 'diffie-hellman-group-exchange-sha1', 'diffie-hellman-group1-sha1'],
-                    cipher: ['aes128-ctr', 'aes192-ctr', 'aes256-ctr', 'aes128-gcm', 'aes128-gcm@openssh.com', 'aes256-gcm', 'aes256-gcm@openssh.com', 'aes128-cbc', '3des-cbc', 'aes192-cbc', 'aes256-cbc'],
-                    hmac: ['hmac-sha2-256', 'hmac-sha2-512', 'hmac-sha1', 'hmac-sha1-96'],
-                    serverHostKey: ['ssh-ed25519', 'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521', 'rsa-sha2-512', 'rsa-sha2-256', 'ssh-rsa', 'ssh-dss']
+                    kex: ['diffie-hellman-group1-sha1', 'diffie-hellman-group14-sha1', 'diffie-hellman-group-exchange-sha1', 'diffie-hellman-group-exchange-sha256', 'curve25519-sha256', 'curve25519-sha256@libssh.org', 'ecdh-sha2-nistp256', 'ecdh-sha2-nistp384', 'ecdh-sha2-nistp521'],
+                    cipher: ['aes128-cbc', '3des-cbc', 'aes192-cbc', 'aes256-cbc', 'blowfish-cbc', 'cast128-cbc', 'arcfour', 'aes128-ctr', 'aes192-ctr', 'aes256-ctr', 'aes128-gcm', 'aes128-gcm@openssh.com', 'aes256-gcm', 'aes256-gcm@openssh.com'],
+                    hmac: ['hmac-sha1', 'hmac-sha1-96', 'hmac-md5', 'hmac-md5-96', 'hmac-sha2-256', 'hmac-sha2-512'],
+                    serverHostKey: ['ssh-rsa', 'ssh-dss', 'ssh-ed25519', 'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521', 'rsa-sha2-512', 'rsa-sha2-256']
                 }
             }
 
@@ -227,6 +238,11 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
             } else {
                 connectConfig.password = Buffer.from(config.password ?? '', 'base64').toString('utf8')
             }
+
+            sshClient.on('keyboard-interactive', (name, instructions, instructionsLang, prompts, finish) => {
+                const password = Buffer.from(config.password ?? '', 'base64').toString('utf8')
+                finish(Array(prompts.length).fill(password))
+            })
 
             console.log(`[SFTP] Starting SSH handshake for ID: ${id}`)
             sshClient.connect(connectConfig)

--- a/electron/src/ipc-handlers.ts
+++ b/electron/src/ipc-handlers.ts
@@ -58,7 +58,11 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
         const sshClient = new Client()
         sshClients.set(id, sshClient)
 
-        const socket = net.connect(config.port || 22, config.host)
+        const socket = net.connect({
+            port: config.port || 22,
+            host: config.host,
+            timeout: 15000
+        })
         sshSockets.set(id, socket)
 
         socket.on('connect', () => {
@@ -70,6 +74,15 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
                 readyTimeout: 20000,
                 keepaliveInterval: 10000,
                 keepaliveCountMax: 3
+            }
+
+            if (config.allowLegacyAlgorithms) {
+                connectConfig.algorithms = {
+                    kex: ['curve25519-sha256', 'curve25519-sha256@libssh.org', 'ecdh-sha2-nistp256', 'ecdh-sha2-nistp384', 'ecdh-sha2-nistp521', 'diffie-hellman-group-exchange-sha256', 'diffie-hellman-group14-sha1', 'diffie-hellman-group-exchange-sha1', 'diffie-hellman-group1-sha1'],
+                    cipher: ['aes128-ctr', 'aes192-ctr', 'aes256-ctr', 'aes128-gcm', 'aes128-gcm@openssh.com', 'aes256-gcm', 'aes256-gcm@openssh.com', 'aes128-cbc', '3des-cbc', 'aes192-cbc', 'aes256-cbc'],
+                    hmac: ['hmac-sha2-256', 'hmac-sha2-512', 'hmac-sha1', 'hmac-sha1-96'],
+                    serverHostKey: ['ssh-ed25519', 'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521', 'rsa-sha2-512', 'rsa-sha2-256', 'ssh-rsa', 'ssh-dss']
+                }
             }
 
             if (config.authType === 'key' && config.privateKeyPath) {
@@ -86,6 +99,11 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
             }
 
             sshClient.connect(connectConfig)
+        })
+
+        socket.on('timeout', () => {
+            event.reply(`ssh-error-${id}`, 'Тайм-аут соединения (TCP)')
+            cleanupConnection(id)
         })
 
         socket.on('error', (err: Error) => {
@@ -186,6 +204,15 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
                 readyTimeout: 20000,
                 keepaliveInterval: 10000,
                 keepaliveCountMax: 3
+            }
+
+            if (config.allowLegacyAlgorithms) {
+                connectConfig.algorithms = {
+                    kex: ['curve25519-sha256', 'curve25519-sha256@libssh.org', 'ecdh-sha2-nistp256', 'ecdh-sha2-nistp384', 'ecdh-sha2-nistp521', 'diffie-hellman-group-exchange-sha256', 'diffie-hellman-group14-sha1', 'diffie-hellman-group-exchange-sha1', 'diffie-hellman-group1-sha1'],
+                    cipher: ['aes128-ctr', 'aes192-ctr', 'aes256-ctr', 'aes128-gcm', 'aes128-gcm@openssh.com', 'aes256-gcm', 'aes256-gcm@openssh.com', 'aes128-cbc', '3des-cbc', 'aes192-cbc', 'aes256-cbc'],
+                    hmac: ['hmac-sha2-256', 'hmac-sha2-512', 'hmac-sha1', 'hmac-sha1-96'],
+                    serverHostKey: ['ssh-ed25519', 'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521', 'rsa-sha2-512', 'rsa-sha2-256', 'ssh-rsa', 'ssh-dss']
+                }
             }
 
             if (config.authType === 'key' && config.privateKeyPath) {

--- a/electron/src/types.ts
+++ b/electron/src/types.ts
@@ -12,6 +12,7 @@ export interface SSHConfig {
     privateKeyPath?: string
     osPrettyName?: string
     initialCommands?: string
+    allowLegacyAlgorithms?: boolean
 }
 
 /**

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -22,6 +22,7 @@ interface SSHConfig {
     privateKeyPath?: string
     osPrettyName?: string
     initialCommands?: string
+    allowLegacyAlgorithms?: boolean
 }
 
 interface AppConfig {

--- a/src/components/ConnectionForm.tsx
+++ b/src/components/ConnectionForm.tsx
@@ -18,14 +18,16 @@ export const ConnectionForm: React.FC<ConnectionFormProps> = ({onConnect, onSave
         password: '',
         authType: 'password',
         privateKeyPath: '',
-        initialCommands: ''
+        initialCommands: '',
+        allowLegacyAlgorithms: false
     });
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [showPassword, setShowPassword] = useState(false);
 
     const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
-        const {name, value} = e.target;
-        setConfig((prev: any) => ({...prev, [name]: value}));
+        const {name, value, type} = e.target as HTMLInputElement;
+        const val = type === 'checkbox' ? (e.target as HTMLInputElement).checked : value;
+        setConfig((prev: any) => ({...prev, [name]: val}));
     };
 
     const handleSelectKey = async () => {
@@ -161,6 +163,20 @@ export const ConnectionForm: React.FC<ConnectionFormProps> = ({onConnect, onSave
                             resize: 'vertical'
                         }}
                     />
+                </div>
+
+                <div style={{display: 'flex', alignItems: 'center', gap: '10px'}}>
+                    <input
+                        type="checkbox"
+                        name="allowLegacyAlgorithms"
+                        id="allowLegacyAlgorithms"
+                        checked={config.allowLegacyAlgorithms || false}
+                        onChange={handleChange}
+                        style={{width: '18px', height: '18px', cursor: 'pointer'}}
+                    />
+                    <label htmlFor="allowLegacyAlgorithms" style={{cursor: 'pointer', fontWeight: 'bold', fontSize: '0.9em'}}>
+                        Разрешить старые алгоритмы (для роутеров)
+                    </label>
                 </div>
 
                 <div>


### PR DESCRIPTION
The user reported being unable to connect to a router at 192.168.1.1. This is typically due to older SSH algorithms being disabled by default in modern SSH libraries or lack of connection timeouts causing the UI to hang.

This PR implements:
1. An opt-in "Legacy Algorithms" toggle in the connection form.
2. An exhaustive list of supported legacy algorithms (e.g., diffie-hellman-group1-sha1, 3des-cbc, ssh-rsa) when the toggle is enabled, ensuring compatibility with older network equipment while maintaining security for modern servers by default.
3. A 15-second TCP connection timeout in the main SSH connection handler (matching the existing SFTP timeout) to provide better user feedback if the host is unreachable.

Verified that the linter passes (within existing baseline) and the logic correctly passes the configuration to the underlying `ssh2` library.

---
*PR created automatically by Jules for task [8031364843701044024](https://jules.google.com/task/8031364843701044024) started by @megoRU*