### PR TITLE
Use uname -a for OS info on 192.168.1.1

### DIFF
--- a/electron/src/ipc-handlers.ts
+++ b/electron/src/ipc-handlers.ts
@@ -5,7 +5,7 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { loadConfig, saveConfig } from './config.js'
 import { getSystemFonts } from './font-service.js'
-import { sshClients, shellStreams, sshSockets, sftpClients, sftpWatchers, cleanupConnection, cleanupAll } from './ssh-manager.js'
+import { sshClients, shellStreams, sshSockets, sftpClients, sftpWatchers, sshConfigs, cleanupConnection, cleanupAll } from './ssh-manager.js'
 import { AppConfig, SshConnectPayload, SftpConnectPayload, SftpFileEntry, SftpProgress } from './types.js'
 
 /**
@@ -54,6 +54,7 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
         shellStreams.delete(id)
         sshClients.delete(id)
         sshSockets.delete(id)
+        sshConfigs.set(id, config)
 
         const sshClient = new Client()
         sshClients.set(id, sshClient)
@@ -145,8 +146,10 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
 
     ipcMain.on('ssh-get-os-info', (event: IpcMainEvent, id: string) => {
         const client = sshClients.get(id)
+        const config = sshConfigs.get(id)
         if (client) {
-            client.exec('cat /etc/os-release', (err, stream) => {
+            const command = config?.host === '192.168.1.1' ? 'uname -a' : 'cat /etc/os-release'
+            client.exec(command, (err, stream) => {
                 if (err) return
                 let output = ''
                 stream.on('data', (data: Buffer) => {

--- a/electron/src/ssh-manager.ts
+++ b/electron/src/ssh-manager.ts
@@ -1,6 +1,7 @@
 import { Client, type ClientChannel, type SFTPWrapper } from 'ssh2'
 import * as net from 'node:net'
 import * as fs from 'node:fs'
+import { SSHConfig } from './types.js'
 
 /** Хранилище активных SSH-клиентов по ID сессии */
 export const sshClients = new Map<string, Client>()
@@ -16,6 +17,9 @@ export const sshSockets = new Map<string, net.Socket>()
 
 /** Хранилище активных вотчеров за файлами по ID сессии и локальному пути */
 export const sftpWatchers = new Map<string, Map<string, fs.FSWatcher>>()
+
+/** Хранилище конфигураций SSH по ID сессии */
+export const sshConfigs = new Map<string, SSHConfig>()
 
 /**
  * Закрывает и удаляет конкретное SSH-соединение по его ID.
@@ -38,6 +42,7 @@ export function cleanupConnection(id: string): void {
     shellStreams.delete(id)
     sshClients.delete(id)
     sshSockets.delete(id)
+    sshConfigs.delete(id)
 }
 
 /**
@@ -56,4 +61,5 @@ export function cleanupAll(): void {
     shellStreams.clear()
     sshClients.clear()
     sshSockets.clear()
+    sshConfigs.clear()
 }


### PR DESCRIPTION
This change modifies the command used to retrieve OS information for the specific host `192.168.1.1`. Instead of the standard `cat /etc/os-release`, it now uses `uname -a`. This was achieved by:
1. Adding a new `sshConfigs` Map in `ssh-manager.ts` to store connection configurations.
2. Updating the `ssh-connect` IPC handler to save the configuration for each session.
3. Updating the `ssh-get-os-info` IPC handler to check the host address and conditionally choose the command.
4. Ensuring proper cleanup of the configuration map in `cleanupConnection` and `cleanupAll`.

---
*PR created automatically by Jules for task [13749781170350999630](https://jules.google.com/task/13749781170350999630) started by @megoRU*