### PR TITLE
Support Legacy SSH Algorithms and Fix SFTP Reconnection Loop

### DIFF
--- a/electron/src/config.ts
+++ b/electron/src/config.ts
@@ -19,7 +19,8 @@ export const DEFAULT_CONFIG: AppConfig = {
     width: 1254,
     height: 909,
     maximized: false,
-    lastUpdateCheck: 0
+    lastUpdateCheck: 0,
+    allowLegacyAlgorithms: false
 }
 
 let cachedConfig: AppConfig | null = null

--- a/electron/src/ipc-handlers.ts
+++ b/electron/src/ipc-handlers.ts
@@ -5,6 +5,36 @@ import * as fs from 'node:fs'
 import * as path from 'node:path'
 import { loadConfig, saveConfig } from './config.js'
 import { getSystemFonts } from './font-service.js'
+
+/**
+ * Возвращает расширенный список алгоритмов SSH, если включена опция "Разрешить старые алгоритмы".
+ * Это позволяет подключаться к устаревшему оборудованию, сохраняя поддержку современных стандартов.
+ */
+function getSshAlgorithms() {
+    if (!loadConfig().allowLegacyAlgorithms) return undefined
+
+    return {
+        kex: [
+            'curve25519-sha256', 'curve25519-sha256@libssh.org', 'ecdh-sha2-nistp256', 'ecdh-sha2-nistp384', 'ecdh-sha2-nistp521',
+            'diffie-hellman-group-exchange-sha256', 'diffie-hellman-group14-sha256',
+            'diffie-hellman-group1-sha1', 'diffie-hellman-group14-sha1', 'diffie-hellman-group-exchange-sha1'
+        ],
+        cipher: [
+            'chacha20-poly1305@openssh.com', 'aes128-ctr', 'aes192-ctr', 'aes256-ctr',
+            'aes128-gcm@openssh.com', 'aes256-gcm@openssh.com', 'aes128-cbc', 'aes192-cbc', 'aes256-cbc',
+            '3des-cbc', 'arcfour', 'arcfour128', 'arcfour256', 'blowfish-cbc', 'cast128-cbc'
+        ],
+        serverHostKey: [
+            'ssh-ed25519', 'ecdsa-sha2-nistp256', 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521',
+            'rsa-sha2-512', 'rsa-sha2-256', 'ssh-rsa', 'ssh-dss'
+        ],
+        hmac: [
+            'hmac-sha2-256-etm@openssh.com', 'hmac-sha2-512-etm@openssh.com', 'hmac-sha1-etm@openssh.com',
+            'hmac-sha2-256', 'hmac-sha2-512', 'hmac-sha1',
+            'hmac-sha1-96', 'hmac-md5', 'hmac-md5-96', 'hmac-ripemd160', 'hmac-ripemd160@openssh.com'
+        ]
+    }
+}
 import { sshClients, shellStreams, sshSockets, sftpClients, sftpWatchers, sshConfigs, cleanupConnection, cleanupAll } from './ssh-manager.js'
 import { AppConfig, SshConnectPayload, SftpConnectPayload, SftpFileEntry, SftpProgress } from './types.js'
 
@@ -85,6 +115,9 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
             } else {
                 connectConfig.password = Buffer.from(config.password ?? '', 'base64').toString('utf8')
             }
+
+            const algorithms = getSshAlgorithms()
+            if (algorithms) connectConfig.algorithms = algorithms
 
             sshClient.connect(connectConfig)
         })
@@ -204,6 +237,9 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
             } else {
                 connectConfig.password = Buffer.from(config.password ?? '', 'base64').toString('utf8')
             }
+
+            const algorithms = getSshAlgorithms()
+            if (algorithms) connectConfig.algorithms = algorithms
 
             console.log(`[SFTP] Starting SSH handshake for ID: ${id}`)
             sshClient.connect(connectConfig)

--- a/electron/src/types.ts
+++ b/electron/src/types.ts
@@ -30,6 +30,7 @@ export interface AppConfig {
     height: number
     maximized: boolean
     lastUpdateCheck?: number
+    allowLegacyAlgorithms?: boolean
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yetanothersshclient",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A modern multi-platform SSH client built with React and Electron",
   "author": "YetAnotherSSHClient Team <support@yash.client>",
   "engines": {

--- a/src/components/SFTPBrowser.tsx
+++ b/src/components/SFTPBrowser.tsx
@@ -37,9 +37,14 @@ export const SFTPBrowser: React.FC<Props> = ({ id, config, visible }) => {
 
     const isConnectingRef = useRef(false);
     const wasConnectedRef = useRef(false);
+    const statusRef = useRef(status);
+
+    useEffect(() => {
+        statusRef.current = status;
+    }, [status]);
 
     const loadDirectory = useCallback(async (dirPath: string, force = false) => {
-        if (!force && status !== 'SFTP-сессия готова') return;
+        if (!force && statusRef.current !== 'SFTP-сессия готова') return;
         const normalizedPath = normalizeRemotePath(dirPath);
         setLoading(true);
         setError(null);
@@ -63,7 +68,7 @@ export const SFTPBrowser: React.FC<Props> = ({ id, config, visible }) => {
         } finally {
             setLoading(false);
         }
-    }, [id, status]);
+    }, [id]);
 
     const connect = useCallback(() => {
         setStatus('Подключение...');
@@ -139,7 +144,7 @@ export const SFTPBrowser: React.FC<Props> = ({ id, config, visible }) => {
             if (typeof unsubFileChanged === 'function') unsubFileChanged();
             ipcRenderer.send('ssh-close', id);
         };
-    }, [id, config, connect, loadDirectory]);
+    }, [id, config]);
 
     const handleDownload = async (filenames: string[]) => {
         if (filenames.length === 0) return;

--- a/src/components/views/AboutView.tsx
+++ b/src/components/views/AboutView.tsx
@@ -24,7 +24,7 @@ export const AboutView: React.FC<AboutViewProps> = ({ uiFontSize }) => {
                 <br />
                 <b style={{ fontSize: '1.5em' }}>YetAnotherSSHClient</b>
                 <br /><br />
-                Версия: 1.2.0
+                Версия: 1.2.1
                 <br /><br />
                 GitHub: <a href="#" onClick={(e) => {
                     e.preventDefault();

--- a/src/components/views/SettingsView.tsx
+++ b/src/components/views/SettingsView.tsx
@@ -75,6 +75,20 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ config, setConfig, s
                         style={{ width: '100%', padding: '8px' }}
                     />
                 </div>
+                <div style={{ marginTop: '10px' }}>
+                    <label style={{ display: 'flex', alignItems: 'center', gap: '10px', cursor: 'pointer' }}>
+                        <input
+                            type="checkbox"
+                            checked={config.allowLegacyAlgorithms || false}
+                            onChange={e => handleUpdate('allowLegacyAlgorithms', e.target.checked)}
+                            style={{ width: '18px', height: '18px', cursor: 'pointer' }}
+                        />
+                        <span>Разрешить старые алгоритмы (diffie-hellman-group1-sha1, 3des-cbc, ssh-rsa)</span>
+                    </label>
+                    <div style={{ fontSize: '0.85em', opacity: 0.6, marginTop: '5px', marginLeft: '28px' }}>
+                        Включите это, если не удается подключиться к старому оборудованию (роутеры, старые сервера).
+                    </div>
+                </div>
             </div>
         </div>
     );

--- a/src/types.ts
+++ b/src/types.ts
@@ -79,4 +79,4 @@ export interface Transfer {
     status: SftpTransferStatus;
     error?: string;
 }
-export const VERSION = '1.2.0';
+export const VERSION = '1.2.1';

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,6 +24,7 @@ export interface AppConfig {
     height: number;
     maximized: boolean;
     lastUpdateCheck?: number;
+    allowLegacyAlgorithms?: boolean;
 }
 
 export interface SshConnectPayload {


### PR DESCRIPTION
This PR addresses SFTP and SSH connection failures to older servers by introducing an opt-in 'Legacy Algorithms' setting. When enabled, it allows the client to use older cryptographic algorithms (like 3DES, SHA1 KEX, and SSH-RSA) while still prioritizing modern, secure defaults for standard connections. Additionally, it fixes a bug in the SFTP browser where it could enter an infinite reconnection loop due to unstable hook dependencies.

---
*PR created automatically by Jules for task [13321418646542086455](https://jules.google.com/task/13321418646542086455) started by @megoRU*