### PR TITLE
Bump version to 1.3.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yetanothersshclient",
-  "version": "1.3.4",
+  "version": "1.3.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yetanothersshclient",
-      "version": "1.3.4",
+      "version": "1.3.5",
       "dependencies": {
         "@xterm/addon-clipboard": "^0.2.0",
         "@xterm/addon-fit": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yetanothersshclient",
   "private": true,
-  "version": "1.3.4",
+  "version": "1.3.5",
   "description": "A modern multi-platform SSH client built with React and Electron",
   "repository": {
     "type": "git",

--- a/src/types.ts
+++ b/src/types.ts
@@ -98,7 +98,7 @@ export interface Transfer {
 
 export type NotificationType = 'success' | 'error' | 'info';
 
-export const VERSION = '1.3.4';
+export const VERSION = '1.3.5';
 
 export interface SftpDownloadResult {
     remotePath: string;


### PR DESCRIPTION
This PR bumps the application version to 1.3.5 across all relevant files: package.json, package-lock.json, and the internal VERSION constant in src/types.ts. Syncing dependencies and running lint checks were also performed to ensure consistency.

---
*PR created automatically by Jules for task [12470953491236287270](https://jules.google.com/task/12470953491236287270) started by @megoRU*