### PR TITLE
Обновление управления шрифтами и fallback терминала

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,6 +1,6 @@
 @font-face { font-family: 'Droid Sans Mono'; src: url('/fonts/Droid Sans Mono.ttf') format('truetype'); font-weight: 400; font-style: normal; }
 @font-face { font-family: 'DejaVu Sans Mono'; src: url('/fonts/DejaVuSansMono.ttf') format('truetype'); font-weight: 400; font-style: normal; }
-@font-face { font-family: 'PT Mono'; src: url('/fonts/PT Mono.ttf') format('truetype'); font-weight: 400; font-style: normal; }
+@font-face { font-family: 'PT Mono'; src: url('/fonts/PTMono-Regular.ttf') format('truetype'); font-weight: 400; font-style: normal; }
 @font-face { font-family: 'Cascadia Code'; src: url('/fonts/Cascadia Code.ttf') format('truetype'); font-weight: 400; font-style: normal; }
 
 @font-face { font-family: 'Fira Code'; src: url('/fonts/FiraCode-Regular.ttf') format('truetype'); font-weight: 400; font-style: normal; }
@@ -17,7 +17,6 @@
 @font-face { font-family: 'Fira Mono'; src: url('/fonts/Fira Mono.ttf') format('truetype'); font-weight: 400; font-style: normal; }
 @font-face { font-family: 'Fira Mono'; src: url('/fonts/Fira Mono Medium.ttf') format('truetype'); font-weight: 500; font-style: normal; }
 
-@font-face { font-family: 'Anonymous Pro'; src: url('/fonts/Anonymous Pro.ttf') format('truetype'); font-weight: 400; font-style: normal; }
 @font-face { font-family: 'Ubuntu Mono'; src: url('/fonts/Ubuntu Mono.ttf') format('truetype'); font-weight: 400; font-style: normal; }
 
 @font-face { font-family: 'Inter'; src: url('/fonts/Inter_18pt-Regular.ttf') format('truetype'); font-weight: 400; font-style: normal; }

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -103,7 +103,7 @@ export const TerminalComponent: React.FC<Props> = ({
             cursorBlink: true,
             cursorStyle: 'block',
             theme: getXtermTheme(theme),
-            fontFamily: "'" + terminalFontName + "', monospace",
+            fontFamily: "'" + terminalFontName + "', 'JetBrains Mono', monospace",
             fontSize: terminalFontSize,
             fontWeight: 400,
             fontWeightBold: 700,
@@ -257,7 +257,7 @@ export const TerminalComponent: React.FC<Props> = ({
     useEffect(() => {
         if (xtermRef.current) {
             xtermRef.current.options.theme = getXtermTheme(theme);
-            xtermRef.current.options.fontFamily = "'" + terminalFontName + "', monospace";
+            xtermRef.current.options.fontFamily = "'" + terminalFontName + "', 'JetBrains Mono', monospace";
             xtermRef.current.options.fontSize = terminalFontSize;
             safeFit();
         }

--- a/src/components/views/SettingsView.tsx
+++ b/src/components/views/SettingsView.tsx
@@ -160,7 +160,9 @@ export const SettingsView: React.FC<SettingsViewProps> = ({ config, setConfig, s
                         <CustomSelect
                             value={config.uiFontName}
                             onChange={val => handleUpdate('uiFontName', val)}
-                            options={systemFonts.map(font => ({ value: font, label: font }))}
+                            options={systemFonts
+                                .filter(font => ['Inter', 'JetBrains Mono', 'Fira Mono'].includes(font))
+                                .map(font => ({ value: font, label: font }))}
                             style={{ width: '200px' }}
                         />
                     </div>

--- a/src/hooks/useSystemFonts.ts
+++ b/src/hooks/useSystemFonts.ts
@@ -3,6 +3,7 @@ const FONTS = [
     'DejaVu Sans Mono',
     'PT Mono',
     'Cascadia Code',
+    'Fira Code',
     'JetBrains Mono',
     'Source Code Pro',
     'Fira Mono',


### PR DESCRIPTION
Выполнил настройку шрифтов согласно требованиям:
1. В настройках шрифта интерфейса теперь доступны только Inter, JetBrains Mono и Fira Mono.
2. В настройках терминала доступны все шрифты, включая добавленный Fira Code.
3. Исправлены ошибки в App.css: путь к PT Mono теперь корректный, удалено объявление отсутствующего шрифта Anonymous Pro.
4. Для терминала настроен обязательный fallback на JetBrains Mono (перед monospace).

---
*PR created automatically by Jules for task [10939940850302082271](https://jules.google.com/task/10939940850302082271) started by @megoRU*