### PR TITLE
Улучшения SFTP: отображение загрузок, удаление при отмене и обновление UI

### DIFF
--- a/electron/src/ipc-handlers.ts
+++ b/electron/src/ipc-handlers.ts
@@ -183,6 +183,19 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
         shellStreams.get(payload.id)?.setWindow(payload.rows, payload.cols, 0, 0)
     })
 
+    ipcMain.handle('fs-stat', async (_, filePath: string) => {
+        try {
+            const stats = fs.statSync(filePath)
+            return {
+                isDir: stats.isDirectory(),
+                size: stats.size
+            }
+        } catch (err) {
+            console.error(`[FS] Error stating file ${filePath}:`, err)
+            return null
+        }
+    })
+
     ipcMain.on('ssh-get-os-info', (event: IpcMainEvent, id: string) => {
         const client = sshClients.get(id)
         if (client) {
@@ -608,7 +621,8 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
             return {
                 path: filePath,
                 name: path.basename(filePath),
-                size: stats.size
+                size: stats.size,
+                isDir: stats.isDirectory()
             }
         })
     })

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yetanothersshclient",
-  "version": "1.5.2",
+  "version": "1.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yetanothersshclient",
-      "version": "1.5.2",
+      "version": "1.5.3",
       "dependencies": {
         "@xterm/addon-clipboard": "^0.2.0",
         "@xterm/addon-fit": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yetanothersshclient",
   "private": true,
-  "version": "1.5.2",
+  "version": "1.5.3",
   "description": "A modern multi-platform SSH client built with React and Electron",
   "repository": {
     "type": "git",

--- a/src/App.css
+++ b/src/App.css
@@ -308,7 +308,6 @@ body.gruvbox-light ::-webkit-scrollbar-thumb:hover {
 }
 .sftp-row.selected {
     background: var(--hover-bg) !important;
-    border-left: 3px solid var(--primary-color);
 }
 
 /* Common Animations */

--- a/src/components/SFTPBrowser.tsx
+++ b/src/components/SFTPBrowser.tsx
@@ -37,6 +37,7 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
     const [modal, setModal] = useState<{
         type: string,
         file?: SftpFileEntry,
+        selectedFiles?: SftpFileEntry[],
         errorMessage?: string,
         cancelPath?: string,
         localPath?: string,
@@ -185,7 +186,8 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
                         progress: data.progress,
                         size: data.total,
                         type: data.type,
-                        status: 'active' as const
+                        status: 'active' as const,
+                        isDir: false // Progress events usually relate to files
                     }, ...prev];
                 }
                 return prev;
@@ -256,7 +258,7 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
     const handleUpload = async () => {
         let newTransfersToUpdate: Transfer[] = [];
         try {
-            const selectedFiles = await ipcRenderer.invoke('sftp-select-files') as { path: string, name: string, size: number }[] | null;
+            const selectedFiles = await ipcRenderer.invoke('sftp-select-files') as { path: string, name: string, size: number, isDir?: boolean }[] | null;
             if (!selectedFiles || selectedFiles.length === 0) return;
 
             newTransfersToUpdate = selectedFiles.map(f => {
@@ -271,7 +273,8 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
                     progress: 0,
                     size: f.size,
                     type: 'upload' as const,
-                    status: 'active' as const
+                    status: 'active' as const,
+                    isDir: f.isDir
                 };
             });
 
@@ -357,14 +360,13 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
     };
 
     const handleDelete = async () => {
-        const items = selectedFilenames.length > 0 ? selectedFilenames : (modal?.file ? [modal.file.filename] : []);
+        const items = modal?.selectedFiles || (modal?.file ? [modal.file] : []);
         setIsProcessing(true);
         try {
-            for (const filename of items) {
-                const file = files.find(f => f.filename === filename);
-                if (file) await ipcRenderer.invoke('sftp-rm', {
+            for (const file of items) {
+                await ipcRenderer.invoke('sftp-rm', {
                     id,
-                    path: `${path}/${filename}`.replace(/\/+/g, '/'),
+                    path: `${path}/${file.filename}`.replace(/\/+/g, '/'),
                     isDir: (file.attrs.mode & 0o040000) !== 0
                 });
             }
@@ -417,14 +419,23 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
         dragCounter.current = 0;
         const droppedFiles = Array.from(e.dataTransfer.files);
         if (droppedFiles.length === 0) return;
-        const droppedFilesWithPaths = droppedFiles.map(f => ({
-            name: f.name,
-            size: f.size,
-            path: ipcRenderer.getPathForFile(f)
-        })).filter(f => f.path);
-        if (droppedFilesWithPaths.length === 0) return;
 
-        const newTransfers: Transfer[] = droppedFilesWithPaths.map(f => {
+        const droppedFilesWithPaths = await Promise.all(droppedFiles.map(async f => {
+            const localPath = ipcRenderer.getPathForFile(f);
+            if (!localPath) return null;
+            const stats = await ipcRenderer.invoke('fs-stat', localPath);
+            return {
+                name: f.name,
+                size: f.size,
+                path: localPath,
+                isDir: stats?.isDir || false
+            };
+        }));
+
+        const validDroppedFiles = droppedFilesWithPaths.filter((f): f is NonNullable<typeof f> => f !== null);
+        if (validDroppedFiles.length === 0) return;
+
+        const newTransfers: Transfer[] = validDroppedFiles.map(f => {
             const remotePath = normalizeRemotePath(`${path}/${f.name}`);
             cancelledPathsRef.current.delete(`upload:${remotePath}`);
             const transferId = Math.random().toString(36).substr(2, 9);
@@ -436,7 +447,8 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
                 progress: 0,
                 size: f.size,
                 type: 'upload' as const,
-                status: 'active' as const
+                status: 'active' as const,
+                isDir: f.isDir
             };
         });
         setActiveTransfers(prev => [...newTransfers, ...prev]);
@@ -619,7 +631,41 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
                         </div>
                     </div>
                 )}
-                    <SftpFileList files={files} selectedFilenames={selectedFilenames} onFileClick={(e, f, i) => {
+                    <SftpFileList files={(() => {
+                        const merged = [...files];
+                        const currentDirTransfers = activeTransfers.filter(t =>
+                            t.type === 'upload' &&
+                            t.status === 'active' &&
+                            normalizeRemotePath(t.remotePath.substring(0, t.remotePath.lastIndexOf('/')) || '/') === normalizeRemotePath(path)
+                        );
+
+                        currentDirTransfers.forEach(t => {
+                            if (!merged.find(f => f.filename === t.filename)) {
+                                merged.push({
+                                    filename: t.filename,
+                                    longname: '',
+                                    attrs: {
+                                        mode: t.isDir ? 0o040000 : 0o100644,
+                                        uid: 0,
+                                        gid: 0,
+                                        size: t.size || 0,
+                                        atime: Date.now() / 1000,
+                                        mtime: Date.now() / 1000
+                                    }
+                                } as SftpFileEntry);
+                            }
+                        });
+
+                        return merged.sort((a, b) => {
+                            if (a.filename === '..') return -1;
+                            if (b.filename === '..') return 1;
+                            const aIsDir = (a.attrs.mode & 0o040000) !== 0;
+                            const bIsDir = (b.attrs.mode & 0o040000) !== 0;
+                            if (aIsDir && !bIsDir) return -1;
+                            if (!aIsDir && bIsDir) return 1;
+                            return a.filename.localeCompare(b.filename);
+                        });
+                    })()} selectedFilenames={selectedFilenames} onFileClick={(e, f, i) => {
                     if (e.shiftKey && lastSelectedIndex !== -1) {
                         const start = Math.min(lastSelectedIndex, i), end = Math.max(lastSelectedIndex, i);
                         setSelectedFilenames(Array.from(new Set([...selectedFilenames, ...files.slice(start, end + 1).map(f => f.filename)])));
@@ -669,6 +715,9 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
                                    cancelledPathsRef.current.add(`${t.type}:${normalizeRemotePath(t.remotePath)}`);
                                    cancelledTransferIdsRef.current.add(t.id);
                                    ipcRenderer.invoke('sftp-cancel-upload', { id, transferId: t.id });
+                                   if (t.type === 'upload') {
+                                       ipcRenderer.invoke('sftp-rm', { id, path: t.remotePath, isDir: t.isDir });
+                                   }
                                    setActiveTransfers(prev => prev.filter(x => x.id !== t.id));
                                }}/>
 
@@ -734,7 +783,14 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
                         label: 'Удалить',
                         icon: <Trash2 size={14}/>,
                         danger: true,
-                        onClick: () => setModal({type: 'delete', file: contextMenu.file})
+                        onClick: () => {
+                            const selectedItems = files.filter(f => selectedFilenames.includes(f.filename));
+                            setModal({
+                                type: 'delete',
+                                file: contextMenu.file,
+                                selectedFiles: selectedItems.length > 0 ? selectedItems : [contextMenu.file!]
+                            });
+                        }
                     }] : [])
                 ]}/>
             )}
@@ -752,7 +808,7 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
                         loadDirectory(path);
                     });
                 }
-            }} selectedCount={selectedFilenames.length}/>
+            }} />
 
         </div>
     );

--- a/src/components/layout/ContextMenu.tsx
+++ b/src/components/layout/ContextMenu.tsx
@@ -46,7 +46,10 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({x, y, options, onClose}
             top = innerHeight - offsetHeight - 8;
         }
 
-        setPos({left, top, ready: true});
+        setPos(prev => {
+            if (prev.left === left && prev.top === top && prev.ready === true) return prev;
+            return {left, top, ready: true};
+        });
     }, [x, y]);
 
     return createPortal(

--- a/src/components/sftp/SftpModals.tsx
+++ b/src/components/sftp/SftpModals.tsx
@@ -6,6 +6,7 @@ interface SftpModalsProps {
     modal: {
         type: string;
         file?: SftpFileEntry;
+        selectedFiles?: SftpFileEntry[];
         errorMessage?: string;
         filename?: string;
         localPath?: string;
@@ -15,7 +16,6 @@ interface SftpModalsProps {
     setModalInput: (val: string) => void;
     onClose: () => void;
     onConfirm: () => void;
-    selectedCount: number;
     isProcessing?: boolean;
 }
 
@@ -25,7 +25,6 @@ export const SftpModals: React.FC<SftpModalsProps> = ({
     setModalInput,
     onClose,
     onConfirm,
-    selectedCount,
     isProcessing = false
 }) => {
     useEffect(() => {
@@ -150,7 +149,39 @@ export const SftpModals: React.FC<SftpModalsProps> = ({
 
                 <div style={{ padding: '25px' }}>
                     {modal.type === 'delete' && (
-                        <p style={{ margin: 0, fontSize: '1.1em' }}>Вы уверены, что хотите удалить <b style={{ wordBreak: 'break-all' }}>{selectedCount > 1 ? `${selectedCount} элементов` : modal.file?.filename}</b>?</p>
+                        <div style={{ display: 'flex', flexDirection: 'column', gap: '15px' }}>
+                            <p style={{ margin: 0, fontSize: '1.1em' }}>
+                                {(() => {
+                                    const items = modal.selectedFiles || (modal.file ? [modal.file] : []);
+                                    if (items.length === 1) {
+                                        const isDir = (items[0].attrs.mode & 0o040000) !== 0;
+                                        return `Вы хотите удалить эт${isDir ? 'у папку' : 'от файл'}?`;
+                                    }
+                                    const allDirs = items.every(i => (i.attrs.mode & 0o040000) !== 0);
+                                    const allFiles = items.every(i => (i.attrs.mode & 0o040000) === 0);
+                                    if (allDirs) return 'Вы хотите удалить эти папки?';
+                                    if (allFiles) return 'Вы хотите удалить эти файлы?';
+                                    return 'Вы хотите удалить эти элементы?';
+                                })()}
+                            </p>
+                            <div style={{
+                                maxHeight: '150px',
+                                overflowY: 'auto',
+                                background: 'rgba(0,0,0,0.05)',
+                                padding: '10px',
+                                borderRadius: '8px',
+                                border: '1px solid var(--border-color)',
+                                display: 'flex',
+                                flexDirection: 'column',
+                                gap: '5px'
+                            }}>
+                                {(modal.selectedFiles || (modal.file ? [modal.file] : [])).map(f => (
+                                    <div key={f.filename} style={{ wordBreak: 'break-all', fontSize: '0.9em', opacity: 0.8 }}>
+                                        • {f.filename}
+                                    </div>
+                                ))}
+                            </div>
+                        </div>
                     )}
 
                     {modal.type === 'fileUpdate' && (
@@ -185,7 +216,7 @@ export const SftpModals: React.FC<SftpModalsProps> = ({
 
                     {modal.type === 'permissions' && permissions && (
                         <div style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
-                            <div style={{ fontWeight: 'bold', fontSize: '0.9em', opacity: 0.9 }}>{modal.file?.filename}</div>
+                            <div style={{ fontWeight: 'bold', fontSize: '0.9em', opacity: 0.9, wordBreak: 'break-all' }}>{modal.file?.filename}</div>
 
                             <div>
                                 <div style={{ display: 'flex', borderBottom: '1px solid var(--border-color)', paddingBottom: '10px', marginBottom: '10px' }}>

--- a/src/components/sftp/SftpModals.tsx
+++ b/src/components/sftp/SftpModals.tsx
@@ -96,7 +96,7 @@ export const SftpModals: React.FC<SftpModalsProps> = ({
             display: 'flex', alignItems: 'center', justifyContent: 'center',
             zIndex: 2000,
             backdropFilter: 'blur(2px)'
-        }} onClick={() => !['rename', 'mkdir', 'fileUpdate'].includes(modal.type) && onClose()}>
+        }} onClick={(e) => e.stopPropagation()}>
             <div style={{
                 background: 'var(--bg-color)',
                 padding: '0',
@@ -117,8 +117,19 @@ export const SftpModals: React.FC<SftpModalsProps> = ({
                 }}>
                     <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
                         {(modal.type === 'error' || modal.type === 'cancelUpload') && <AlertTriangle color="#cc241d" size={20} />}
-                        <h3 style={{ margin: 0, fontSize: '1.2em' }}>
-                            {modal.type === 'delete' && 'Удаление'}
+                        <h3 style={{ margin: 0, fontSize: '1.1em', lineHeight: '1.4' }}>
+                            {modal.type === 'delete' && (() => {
+                                const items = modal.selectedFiles || (modal.file ? [modal.file] : []);
+                                if (items.length === 1) {
+                                    const isDir = (items[0].attrs.mode & 0o040000) !== 0;
+                                    return `Вы хотите удалить эт${isDir ? 'у папку' : 'от файл'}?`;
+                                }
+                                const allDirs = items.every(i => (i.attrs.mode & 0o040000) !== 0);
+                                const allFiles = items.every(i => (i.attrs.mode & 0o040000) === 0);
+                                if (allDirs) return 'Вы хотите удалить эти папки?';
+                                if (allFiles) return 'Вы хотите удалить эти файлы?';
+                                return 'Вы хотите удалить эти элементы?';
+                            })()}
                             {modal.type === 'rename' && 'Переименование'}
                             {modal.type === 'mkdir' && 'Создать папку'}
                             {modal.type === 'permissions' && 'Права доступа'}
@@ -150,20 +161,6 @@ export const SftpModals: React.FC<SftpModalsProps> = ({
                 <div style={{ padding: '25px' }}>
                     {modal.type === 'delete' && (
                         <div style={{ display: 'flex', flexDirection: 'column', gap: '15px' }}>
-                            <p style={{ margin: 0, fontSize: '1.1em' }}>
-                                {(() => {
-                                    const items = modal.selectedFiles || (modal.file ? [modal.file] : []);
-                                    if (items.length === 1) {
-                                        const isDir = (items[0].attrs.mode & 0o040000) !== 0;
-                                        return `Вы хотите удалить эт${isDir ? 'у папку' : 'от файл'}?`;
-                                    }
-                                    const allDirs = items.every(i => (i.attrs.mode & 0o040000) !== 0);
-                                    const allFiles = items.every(i => (i.attrs.mode & 0o040000) === 0);
-                                    if (allDirs) return 'Вы хотите удалить эти папки?';
-                                    if (allFiles) return 'Вы хотите удалить эти файлы?';
-                                    return 'Вы хотите удалить эти элементы?';
-                                })()}
-                            </p>
                             <div style={{
                                 maxHeight: '150px',
                                 overflowY: 'auto',
@@ -270,16 +267,6 @@ export const SftpModals: React.FC<SftpModalsProps> = ({
                     )}
 
                     <div style={{ display: 'flex', justifyContent: 'flex-end', gap: '12px', marginTop: '30px' }}>
-                        {modal.type !== 'error' && (
-                            <button
-                                className="btn-secondary"
-                                onClick={onClose}
-                                disabled={isProcessing}
-                                style={{ padding: '10px 20px', minWidth: '100px' }}
-                            >
-                                Отмена
-                            </button>
-                        )}
                         <button
                             className="btn-primary"
                             onClick={onConfirm}

--- a/src/types.ts
+++ b/src/types.ts
@@ -95,11 +95,12 @@ export interface Transfer {
     type: 'upload' | 'download';
     status: SftpTransferStatus;
     error?: string;
+    isDir?: boolean;
 }
 
 export type NotificationType = 'success' | 'error' | 'info';
 
-export const VERSION = '1.5.2';
+export const VERSION = '1.5.3';
 
 export interface SftpDownloadResult {
     remotePath: string;


### PR DESCRIPTION
### Список изменений:

1. **Бамп версии:** Приложение обновлено до версии **1.5.3**.
2. **Визуальные улучшения:**
   * Убрана красная полоска слева при выборе файла в списке SFTP.
   * Добавлена поддержка переноса длинных имен файлов (`word-break: break-all`) в модальных окнах удаления и прав доступа.
3. **Функциональность SFTP:**
   * **Оптимистичное отображение:** Теперь файлы, которые находятся в процессе загрузки, сразу отображаются в списке файлов текущей директории.
   * **Очистка при отмене:** При отмене загрузки файла или папки на сервер, недогруженные элементы теперь автоматически удаляются с сервера.
   * **Новый IPC-хендлер:** Добавлен `fs-stat` для получения информации о локальных файлах.
4. **Улучшение модальных окон:**
   * Модальное окно удаления теперь имеет динамический заголовок в зависимости от типа выбранных элементов (файл, папка, элементы и т.д.).
   * В окне удаления теперь выводится список всех выбранных для удаления элементов.
5. **Исправление ошибок:**
   * Устранены некоторые предупреждения линтера и потенциальные проблемы с производительностью в контекстном меню.

---
*PR created automatically by Jules for task [12461511383644473172](https://jules.google.com/task/12461511383644473172) started by @megoRU*