### PR TITLE
Устранение мерцания при загрузке папок в SFTP

### DIFF
--- a/electron/src/ipc-handlers.ts
+++ b/electron/src/ipc-handlers.ts
@@ -881,8 +881,8 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
         return true
     })
 
-    ipcMain.handle('sftp-upload-direct', async (_, payload: { id: string; localPath: string; remotePath: string }): Promise<boolean> => {
-        const { id, localPath, remotePath } = payload
+    ipcMain.handle('sftp-upload-direct', async (_, payload: { id: string; localPath: string; remotePath: string; transferId?: string }): Promise<boolean> => {
+        const { id, localPath, remotePath, transferId = 'direct-upload' } = payload
         const sftp = sftpClients.get(id)
         if (!sftp) throw new Error('SFTP client not found')
 
@@ -892,7 +892,7 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
                 else {
                     const win = getMainWindow()
                     if (win) {
-                        const progress: SftpProgress = { id: 'direct-upload', remotePath, progress: 100, type: 'upload' }
+                        const progress: SftpProgress = { id: transferId, remotePath, progress: 100, type: 'upload' }
                         win.webContents.send(`sftp-progress-${id}`, progress)
                     }
                     resolve(true)

--- a/electron/src/ipc-handlers.ts
+++ b/electron/src/ipc-handlers.ts
@@ -183,12 +183,31 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
         shellStreams.get(payload.id)?.setWindow(payload.rows, payload.cols, 0, 0)
     })
 
+    /**
+     * Рекурсивно вычисляет суммарный размер файлов в папке.
+     */
+    function getFolderSize(dirPath: string): number {
+        let size = 0
+        const files = fs.readdirSync(dirPath)
+        for (const file of files) {
+            const filePath = path.join(dirPath, file)
+            const stats = fs.statSync(filePath)
+            if (stats.isDirectory()) {
+                size += getFolderSize(filePath)
+            } else {
+                size += stats.size
+            }
+        }
+        return size
+    }
+
     ipcMain.handle('fs-stat', async (_, filePath: string) => {
         try {
             const stats = fs.statSync(filePath)
+            const isDir = stats.isDirectory()
             return {
-                isDir: stats.isDirectory(),
-                size: stats.size
+                isDir,
+                size: isDir ? getFolderSize(filePath) : stats.size
             }
         } catch (err) {
             console.error(`[FS] Error stating file ${filePath}:`, err)
@@ -610,19 +629,20 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
 
     ipcMain.handle('sftp-select-files', async () => {
         const { canceled, filePaths } = await dialog.showOpenDialog({
-            properties: ['openFile', 'multiSelections'],
-            title: 'Выберите файлы для загрузки'
+            properties: ['openFile', 'openDirectory', 'multiSelections'],
+            title: 'Выберите файлы или папки для загрузки'
         })
 
         if (canceled || filePaths.length === 0) return null
 
         return filePaths.map(filePath => {
             const stats = fs.statSync(filePath)
+            const isDir = stats.isDirectory()
             return {
                 path: filePath,
                 name: path.basename(filePath),
-                size: stats.size,
-                isDir: stats.isDirectory()
+                size: isDir ? getFolderSize(filePath) : stats.size,
+                isDir
             }
         })
     })

--- a/electron/src/ipc-handlers.ts
+++ b/electron/src/ipc-handlers.ts
@@ -635,10 +635,17 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
         }
     })
 
-    ipcMain.handle('sftp-select-files', async () => {
+    ipcMain.handle('sftp-select-files', async (_, mode: 'file' | 'folder' = 'file') => {
+        const properties: any[] = ['multiSelections']
+        if (mode === 'folder') {
+            properties.push('openDirectory')
+        } else {
+            properties.push('openFile')
+        }
+
         const { canceled, filePaths } = await dialog.showOpenDialog({
-            properties: ['openFile', 'openDirectory', 'multiSelections'],
-            title: 'Выберите файлы или папки для загрузки'
+            properties,
+            title: mode === 'folder' ? 'Выберите папки для загрузки' : 'Выберите файлы для загрузки'
         })
 
         if (canceled || filePaths.length === 0) return null

--- a/electron/src/ipc-handlers.ts
+++ b/electron/src/ipc-handlers.ts
@@ -188,15 +188,23 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
      */
     function getFolderSize(dirPath: string): number {
         let size = 0
-        const files = fs.readdirSync(dirPath)
-        for (const file of files) {
-            const filePath = path.join(dirPath, file)
-            const stats = fs.statSync(filePath)
-            if (stats.isDirectory()) {
-                size += getFolderSize(filePath)
-            } else {
-                size += stats.size
+        try {
+            const files = fs.readdirSync(dirPath)
+            for (const file of files) {
+                const filePath = path.join(dirPath, file)
+                try {
+                    const stats = fs.statSync(filePath)
+                    if (stats.isDirectory()) {
+                        size += getFolderSize(filePath)
+                    } else {
+                        size += stats.size
+                    }
+                } catch (e) {
+                    console.error(`[FS] Error stating ${filePath}:`, e)
+                }
             }
+        } catch (e) {
+            console.error(`[FS] Error reading directory ${dirPath}:`, e)
         }
         return size
     }

--- a/electron/src/ipc-handlers.ts
+++ b/electron/src/ipc-handlers.ts
@@ -193,7 +193,8 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
             for (const file of files) {
                 const filePath = path.join(dirPath, file)
                 try {
-                    const stats = fs.statSync(filePath)
+                    const stats = fs.lstatSync(filePath)
+                    if (stats.isSymbolicLink()) continue
                     if (stats.isDirectory()) {
                         size += getFolderSize(filePath)
                     } else {

--- a/src/components/SFTPBrowser.tsx
+++ b/src/components/SFTPBrowser.tsx
@@ -150,6 +150,7 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
         });
 
         const unsubProgress = ipcRenderer.on(`sftp-progress-${id}`, (...args: unknown[]) => {
+            // Обработка прогресса загрузки/скачивания файлов и папок
             const data = args[0] as SftpProgress;
             const normalizedPath = normalizeRemotePath(data.remotePath);
 

--- a/src/components/SFTPBrowser.tsx
+++ b/src/components/SFTPBrowser.tsx
@@ -509,7 +509,7 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
         const validDroppedFiles = droppedFilesWithPaths.filter((f): f is NonNullable<typeof f> => f !== null);
         if (validDroppedFiles.length === 0) return;
 
-        const newTransfers: Transfer[] = validDroppedFiles.map(f => {
+        const newTransfers: Transfer[] = validDroppedFiles.map((f, idx) => {
             const remotePath = normalizeRemotePath(`${path}/${f.name}`);
             cancelledPathsRef.current.delete(`upload:${remotePath}`);
             const transferId = Math.random().toString(36).substr(2, 9);
@@ -519,7 +519,8 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
                 filename: f.name,
                 remotePath,
                 progress: 0,
-                size: f.size,
+                // Используем размер из stats (полученный через ipc), так как f.size от браузера всегда 0 для папок
+                size: droppedFilesWithPaths[idx]?.size || 0,
                 type: 'upload' as const,
                 status: 'active' as const,
                 isDir: f.isDir
@@ -845,24 +846,26 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
                         onClose={() => setModal(null)} onConfirm={() => {
                 if (modal?.type === 'delete') handleDelete(); else if (modal?.type === 'rename') handleRename(); else if (modal?.type === 'mkdir') handleCreateDirectory(); else if (modal?.type === 'permissions') handlePermissions(); else if (modal?.type === 'error') setModal(null); else if (modal?.type === 'cancelUpload') setModal(null); else if (modal?.type === 'fileUpdate') {
                     const transferId = Math.random().toString(36).substr(2, 9);
-                    const newTransfer: Transfer = {
-                        id: transferId,
-                        filename: modal.filename || 'unknown',
-                        remotePath: modal.remotePath!,
-                        progress: 0,
-                        size: 0,
-                        type: 'upload',
-                        status: 'active'
-                    };
-                    setActiveTransfers(prev => [newTransfer, ...prev]);
-                    ipcRenderer.invoke('sftp-upload-direct', {
-                        id,
-                        localPath: modal.localPath,
-                        remotePath: modal.remotePath,
-                        transferId
-                    }).then(() => {
-                        setModal(null);
-                        loadDirectory(path);
+                    ipcRenderer.invoke('fs-stat', modal.localPath).then((stats: { size: number }) => {
+                        const newTransfer: Transfer = {
+                            id: transferId,
+                            filename: modal.filename || 'unknown',
+                            remotePath: modal.remotePath!,
+                            progress: 0,
+                            size: stats?.size || 0,
+                            type: 'upload',
+                            status: 'active'
+                        };
+                        setActiveTransfers(prev => [newTransfer, ...prev]);
+                        ipcRenderer.invoke('sftp-upload-direct', {
+                            id,
+                            localPath: modal.localPath,
+                            remotePath: modal.remotePath,
+                            transferId
+                        }).then(() => {
+                            setModal(null);
+                            loadDirectory(path);
+                        });
                     });
                 }
             }} />

--- a/src/components/SFTPBrowser.tsx
+++ b/src/components/SFTPBrowser.tsx
@@ -101,8 +101,15 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
         setError(null);
         setSelectedFilenames([]);
         setLastSelectedIndex(-1);
+
         try {
             const list = await ipcRenderer.invoke('sftp-readdir', {id, path: normalizedPath}) as SftpFileEntry[] | null;
+
+            // Очищаем успешно завершенные или отмененные трансферы при обновлении списка файлов,
+            // так как они уже должны быть видны в актуальном списке от сервера.
+            // Делаем это ПОСЛЕ получения данных, но перед отрисовкой, чтобы минимизировать зазор.
+            setActiveTransfers(prev => prev.filter(t => t.status === 'active'));
+
             let filteredList = (list || []).filter((f: SftpFileEntry) => !f.filename.startsWith('.'));
             filteredList.sort((a, b) => {
                 const aMode = a.attrs.mode;
@@ -194,60 +201,71 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
             const normalizedPath = normalizeRemotePath(data.remotePath);
 
             if (data.id && cancelledTransferIdsRef.current.has(data.id)) return;
-            if (!data.id && cancelledPathsRef.current.has(`${data.type}:${normalizedPath}`)) return;
+            if (cancelledPathsRef.current.has(`${data.type}:${normalizedPath}`)) return;
 
             pendingUpdatesRef.current.push(data);
 
-            if (!throttleTimerRef.current) {
-                const isCritical = data.progress >= 100 || data.progress === 0;
-                throttleTimerRef.current = setTimeout(() => {
+            const processUpdates = () => {
+                if (throttleTimerRef.current) {
+                    clearTimeout(throttleTimerRef.current);
                     throttleTimerRef.current = null;
-                    const updates = [...pendingUpdatesRef.current];
-                    pendingUpdatesRef.current = [];
+                }
+                const updates = [...pendingUpdatesRef.current];
+                pendingUpdatesRef.current = [];
+                if (updates.length === 0) return;
 
-                    setActiveTransfers(prev => {
-                        let next = [...prev];
-                        let changed = false;
+                setActiveTransfers(prev => {
+                    const next = [...prev];
+                    let changed = false;
 
-                        for (const d of updates) {
-                            const dPath = normalizeRemotePath(d.remotePath);
-                            const idx = next.findIndex(t =>
-                                d.id ? t.id === d.id : (normalizeRemotePath(t.remotePath) === dPath && t.type === d.type && t.status === 'active')
-                            );
+                    for (const d of updates) {
+                        const dPath = normalizeRemotePath(d.remotePath);
+                        if (d.id && cancelledTransferIdsRef.current.has(d.id)) continue;
+                        if (cancelledPathsRef.current.has(`${d.type}:${dPath}`)) continue;
 
-                            if (idx !== -1) {
-                                const t = next[idx];
-                                const pathMatches = normalizeRemotePath(d.remotePath) === normalizeRemotePath(t.remotePath);
-                                const isFinished = d.progress >= 100 && pathMatches;
-                                const newProgress = pathMatches ? d.progress : t.progress;
-                                const newStatus = isFinished ? 'success' : 'active';
+                        const idx = next.findIndex(t => d.id ? t.id === d.id : (normalizeRemotePath(t.remotePath) === dPath && t.type === d.type && t.status === 'active'));
 
-                                if (t.progress !== newProgress || t.status !== newStatus) {
-                                    next[idx] = {
-                                        ...t,
-                                        progress: newProgress,
-                                        size: pathMatches ? (d.total || t.size) : t.size,
-                                        status: newStatus as "active" | "success"
-                                    };
-                                    changed = true;
-                                }
-                            } else if (d.progress < 100) {
-                                next = [{
-                                    id: d.id || Math.random().toString(36).substr(2, 9),
-                                    filename: dPath.split('/').pop() || 'unknown',
-                                    remotePath: dPath,
-                                    progress: d.progress,
-                                    size: d.total,
-                                    type: d.type,
-                                    status: 'active' as const,
-                                    isDir: false
-                                }, ...next];
+                        if (idx !== -1) {
+                            const t = next[idx];
+                            const pathMatches = dPath === normalizeRemotePath(t.remotePath);
+                            const isFinished = d.progress >= 100 && pathMatches;
+                            const newProgress = pathMatches ? d.progress : t.progress;
+                            const newStatus = isFinished ? 'success' : 'active';
+
+                            if (t.progress !== newProgress || t.status !== newStatus) {
+                                next[idx] = {
+                                    ...t,
+                                    progress: newProgress,
+                                    size: pathMatches ? (d.total || t.size) : t.size,
+                                    status: newStatus as "active" | "success"
+                                };
                                 changed = true;
                             }
+                        } else if (d.progress < 100 && !d.id) {
+                            // Автоматически добавляем новый трансфер, если он не был найден И у него нет ID.
+                            // Наличие ID означает, что это событие от уже существующего (или отмененного) трансфера.
+                            next.unshift({
+                                id: Math.random().toString(36).substr(2, 9),
+                                filename: dPath.split('/').pop() || 'unknown',
+                                remotePath: dPath,
+                                progress: d.progress,
+                                size: d.total,
+                                type: d.type,
+                                status: 'active' as const,
+                                isDir: false
+                            });
+                            changed = true;
                         }
-                        return changed ? next : prev;
-                    });
-                }, isCritical ? 10 : 150);
+                    }
+                    return changed ? next : prev;
+                });
+            };
+
+            const isCritical = data.progress >= 100 || data.progress === 0;
+            if (isCritical) {
+                processUpdates();
+            } else if (!throttleTimerRef.current) {
+                throttleTimerRef.current = setTimeout(processUpdates, 150);
             }
         });
 
@@ -736,13 +754,18 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
             <SftpTransferPanel activeTransfers={activeTransfers} setActiveTransfers={setActiveTransfers}
                                primaryRed={primaryRed}
                                onCancelTransfer={(t) => {
-                                   cancelledPathsRef.current.add(`${t.type}:${normalizeRemotePath(t.remotePath)}`);
+                                   const normPath = normalizeRemotePath(t.remotePath);
+                                   cancelledPathsRef.current.add(`${t.type}:${normPath}`);
                                    cancelledTransferIdsRef.current.add(t.id);
+
+                                   // Немедленно удаляем из состояния и очищаем очередь, чтобы не было "двойного клика"
+                                   pendingUpdatesRef.current = pendingUpdatesRef.current.filter(u => u.id !== t.id && normalizeRemotePath(u.remotePath) !== normPath);
+                                   setActiveTransfers(prev => prev.filter(x => x.id !== t.id));
+
                                    ipcRenderer.invoke('sftp-cancel-upload', { id, transferId: t.id });
                                    if (t.type === 'upload') {
                                        ipcRenderer.invoke('sftp-rm', { id, path: t.remotePath, isDir: t.isDir });
                                    }
-                                   setActiveTransfers(prev => prev.filter(x => x.id !== t.id));
                                }}/>
 
             {contextMenu && (
@@ -823,10 +846,22 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
                         isProcessing={isProcessing}
                         onClose={() => setModal(null)} onConfirm={() => {
                 if (modal?.type === 'delete') handleDelete(); else if (modal?.type === 'rename') handleRename(); else if (modal?.type === 'mkdir') handleCreateDirectory(); else if (modal?.type === 'permissions') handlePermissions(); else if (modal?.type === 'error') setModal(null); else if (modal?.type === 'cancelUpload') setModal(null); else if (modal?.type === 'fileUpdate') {
+                    const transferId = Math.random().toString(36).substr(2, 9);
+                    const newTransfer: Transfer = {
+                        id: transferId,
+                        filename: modal.filename || 'unknown',
+                        remotePath: modal.remotePath!,
+                        progress: 0,
+                        size: 0,
+                        type: 'upload',
+                        status: 'active'
+                    };
+                    setActiveTransfers(prev => [newTransfer, ...prev]);
                     ipcRenderer.invoke('sftp-upload-direct', {
                         id,
                         localPath: modal.localPath,
-                        remotePath: modal.remotePath
+                        remotePath: modal.remotePath,
+                        transferId
                     }).then(() => {
                         setModal(null);
                         loadDirectory(path);

--- a/src/components/SFTPBrowser.tsx
+++ b/src/components/SFTPBrowser.tsx
@@ -234,7 +234,9 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
                                 next[idx] = {
                                     ...t,
                                     progress: newProgress,
-                                    size: pathMatches ? (d.total || t.size) : t.size,
+                                    // Для папок сохраняем ранее вычисленный рекурсивный размер,
+                                    // чтобы он не перезаписывался размером отдельного вложенного файла
+                                    size: t.isDir ? t.size : (pathMatches ? (d.total || t.size) : t.size),
                                     status: newStatus as "active" | "success"
                                 };
                                 changed = true;
@@ -500,7 +502,7 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
             const stats = await ipcRenderer.invoke('fs-stat', localPath);
             return {
                 name: f.name,
-                size: f.size,
+                size: stats?.size || 0,
                 path: localPath,
                 isDir: stats?.isDir || false
             };
@@ -509,7 +511,7 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
         const validDroppedFiles = droppedFilesWithPaths.filter((f): f is NonNullable<typeof f> => f !== null);
         if (validDroppedFiles.length === 0) return;
 
-        const newTransfers: Transfer[] = validDroppedFiles.map((f, idx) => {
+        const newTransfers: Transfer[] = validDroppedFiles.map((f) => {
             const remotePath = normalizeRemotePath(`${path}/${f.name}`);
             cancelledPathsRef.current.delete(`upload:${remotePath}`);
             const transferId = Math.random().toString(36).substr(2, 9);
@@ -519,8 +521,7 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
                 filename: f.name,
                 remotePath,
                 progress: 0,
-                // Используем размер из stats (полученный через ipc), так как f.size от браузера всегда 0 для папок
-                size: droppedFilesWithPaths[idx]?.size || 0,
+                size: f.size,
                 type: 'upload' as const,
                 status: 'active' as const,
                 isDir: f.isDir
@@ -533,7 +534,7 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
                 id,
                 remoteDir: path,
                 transfers: newTransfers.map((t, idx) => ({
-                    localPath: droppedFilesWithPaths[idx].path,
+                    localPath: validDroppedFiles[idx].path,
                     transferId: t.id
                 }))
             });

--- a/src/components/SFTPBrowser.tsx
+++ b/src/components/SFTPBrowser.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useRef, useState} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {Archive, Download, Edit, MousePointer2, RefreshCw, Shield, Trash2, UploadCloud} from 'lucide-react';
 import {ContextMenu} from './layout/ContextMenu';
 import {SftpToolbar} from './sftp/SftpToolbar';
@@ -25,6 +25,8 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
     const [status, setStatus] = useState('Подключение...');
     const [isProcessing, setIsProcessing] = useState(false);
     const [activeTransfers, setActiveTransfers] = useState<Transfer[]>([]);
+    const pendingUpdatesRef = useRef<SftpProgress[]>([]);
+    const throttleTimerRef = useRef<NodeJS.Timeout | null>(null);
     const [isDragging, setIsDragging] = useState(false);
     const dragCounter = useRef(0);
     const pendingDeletesRef = useRef<string[]>([]);
@@ -45,6 +47,44 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
         filename?: string
     } | null>(null);
     const [modalInput, setModalInput] = useState('');
+
+    const mergedFileList = useMemo(() => {
+        const merged = [...files];
+        const existingNames = new Set(files.map(f => f.filename));
+        const currentDirTransfers = activeTransfers.filter(t =>
+            t.type === 'upload' &&
+            (t.status === 'active' || t.status === 'success') &&
+            normalizeRemotePath(t.remotePath.substring(0, t.remotePath.lastIndexOf('/')) || '/') === normalizeRemotePath(path)
+        );
+
+        currentDirTransfers.forEach(t => {
+            if (!existingNames.has(t.filename)) {
+                merged.push({
+                    filename: t.filename,
+                    longname: '',
+                    attrs: {
+                        mode: t.isDir ? 0o040000 : 0o100644,
+                        uid: 0,
+                        gid: 0,
+                        size: t.size || 0,
+                        atime: Date.now() / 1000,
+                        mtime: Date.now() / 1000
+                    }
+                } as SftpFileEntry);
+                existingNames.add(t.filename);
+            }
+        });
+
+        return merged.sort((a, b) => {
+            if (a.filename === '..') return -1;
+            if (b.filename === '..') return 1;
+            const aIsDir = (a.attrs.mode & 0o040000) !== 0;
+            const bIsDir = (b.attrs.mode & 0o040000) !== 0;
+            if (aIsDir && !bIsDir) return -1;
+            if (!aIsDir && bIsDir) return 1;
+            return a.filename.localeCompare(b.filename);
+        });
+    }, [files, activeTransfers, path]);
 
     const isConnectingRef = useRef(false);
     const wasConnectedRef = useRef(false);
@@ -150,48 +190,65 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
         });
 
         const unsubProgress = ipcRenderer.on(`sftp-progress-${id}`, (...args: unknown[]) => {
-            // Обработка прогресса загрузки/скачивания файлов и папок
             const data = args[0] as SftpProgress;
             const normalizedPath = normalizeRemotePath(data.remotePath);
 
-            if (data.id) {
-                if (cancelledTransferIdsRef.current.has(data.id)) return;
-            } else {
-                if (cancelledPathsRef.current.has(`${data.type}:${normalizedPath}`)) return;
+            if (data.id && cancelledTransferIdsRef.current.has(data.id)) return;
+            if (!data.id && cancelledPathsRef.current.has(`${data.type}:${normalizedPath}`)) return;
+
+            pendingUpdatesRef.current.push(data);
+
+            if (!throttleTimerRef.current) {
+                const isCritical = data.progress >= 100 || data.progress === 0;
+                throttleTimerRef.current = setTimeout(() => {
+                    throttleTimerRef.current = null;
+                    const updates = [...pendingUpdatesRef.current];
+                    pendingUpdatesRef.current = [];
+
+                    setActiveTransfers(prev => {
+                        let next = [...prev];
+                        let changed = false;
+
+                        for (const d of updates) {
+                            const dPath = normalizeRemotePath(d.remotePath);
+                            const idx = next.findIndex(t =>
+                                d.id ? t.id === d.id : (normalizeRemotePath(t.remotePath) === dPath && t.type === d.type && t.status === 'active')
+                            );
+
+                            if (idx !== -1) {
+                                const t = next[idx];
+                                const pathMatches = normalizeRemotePath(d.remotePath) === normalizeRemotePath(t.remotePath);
+                                const isFinished = d.progress >= 100 && pathMatches;
+                                const newProgress = pathMatches ? d.progress : t.progress;
+                                const newStatus = isFinished ? 'success' : 'active';
+
+                                if (t.progress !== newProgress || t.status !== newStatus) {
+                                    next[idx] = {
+                                        ...t,
+                                        progress: newProgress,
+                                        size: pathMatches ? (d.total || t.size) : t.size,
+                                        status: newStatus as "active" | "success"
+                                    };
+                                    changed = true;
+                                }
+                            } else if (d.progress < 100) {
+                                next = [{
+                                    id: d.id || Math.random().toString(36).substr(2, 9),
+                                    filename: dPath.split('/').pop() || 'unknown',
+                                    remotePath: dPath,
+                                    progress: d.progress,
+                                    size: d.total,
+                                    type: d.type,
+                                    status: 'active' as const,
+                                    isDir: false
+                                }, ...next];
+                                changed = true;
+                            }
+                        }
+                        return changed ? next : prev;
+                    });
+                }, isCritical ? 10 : 150);
             }
-
-            setActiveTransfers(prev => {
-                const existingIndex = prev.findIndex(t =>
-                    data.id ? t.id === data.id : (normalizeRemotePath(t.remotePath) === normalizedPath && t.type === data.type && t.status === 'active')
-                );
-
-                if (existingIndex !== -1) {
-                    const newTransfers = [...prev];
-                    const existingTransfer = newTransfers[existingIndex];
-                    const isFinished = data.progress >= 100 && normalizeRemotePath(data.remotePath) === normalizeRemotePath(existingTransfer.remotePath);
-
-                    newTransfers[existingIndex] = {
-                        ...existingTransfer,
-                        progress: data.progress,
-                        size: data.total || existingTransfer.size,
-                        status: isFinished ? 'success' : 'active'
-                    };
-                    return newTransfers;
-                }
-                if (data.progress < 100) {
-                    return [{
-                        id: data.id || Math.random().toString(36).substr(2, 9),
-                        filename: normalizedPath.split('/').pop() || 'unknown',
-                        remotePath: normalizedPath,
-                        progress: data.progress,
-                        size: data.total,
-                        type: data.type,
-                        status: 'active' as const,
-                        isDir: false // Progress events usually relate to files
-                    }, ...prev];
-                }
-                return prev;
-            });
         });
 
         connect();
@@ -203,6 +260,7 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
             if (typeof unsubError === 'function') unsubError();
             if (typeof unsubProgress === 'function') unsubProgress();
             if (typeof unsubFileChanged === 'function') unsubFileChanged();
+            if (throttleTimerRef.current) clearTimeout(throttleTimerRef.current);
             ipcRenderer.send('ssh-close', id);
         };
     }, [id, config]);
@@ -631,41 +689,7 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
                         </div>
                     </div>
                 )}
-                    <SftpFileList files={(() => {
-                        const merged = [...files];
-                        const currentDirTransfers = activeTransfers.filter(t =>
-                            t.type === 'upload' &&
-                            (t.status === 'active' || t.status === 'success') &&
-                            normalizeRemotePath(t.remotePath.substring(0, t.remotePath.lastIndexOf('/')) || '/') === normalizeRemotePath(path)
-                        );
-
-                        currentDirTransfers.forEach(t => {
-                            if (!merged.find(f => f.filename === t.filename)) {
-                                merged.push({
-                                    filename: t.filename,
-                                    longname: '',
-                                    attrs: {
-                                        mode: t.isDir ? 0o040000 : 0o100644,
-                                        uid: 0,
-                                        gid: 0,
-                                        size: t.size || 0,
-                                        atime: Date.now() / 1000,
-                                        mtime: Date.now() / 1000
-                                    }
-                                } as SftpFileEntry);
-                            }
-                        });
-
-                        return merged.sort((a, b) => {
-                            if (a.filename === '..') return -1;
-                            if (b.filename === '..') return 1;
-                            const aIsDir = (a.attrs.mode & 0o040000) !== 0;
-                            const bIsDir = (b.attrs.mode & 0o040000) !== 0;
-                            if (aIsDir && !bIsDir) return -1;
-                            if (!aIsDir && bIsDir) return 1;
-                            return a.filename.localeCompare(b.filename);
-                        });
-                    })()} selectedFilenames={selectedFilenames} onFileClick={(e, f, i) => {
+                    <SftpFileList files={mergedFileList} selectedFilenames={selectedFilenames} onFileClick={(e, f, i) => {
                     if (e.shiftKey && lastSelectedIndex !== -1) {
                         const start = Math.min(lastSelectedIndex, i), end = Math.max(lastSelectedIndex, i);
                         setSelectedFilenames(Array.from(new Set([...selectedFilenames, ...files.slice(start, end + 1).map(f => f.filename)])));

--- a/src/components/SFTPBrowser.tsx
+++ b/src/components/SFTPBrowser.tsx
@@ -167,14 +167,13 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
                 if (existingIndex !== -1) {
                     const newTransfers = [...prev];
                     const existingTransfer = newTransfers[existingIndex];
+                    const isFinished = data.progress >= 100 && normalizeRemotePath(data.remotePath) === normalizeRemotePath(existingTransfer.remotePath);
+
                     newTransfers[existingIndex] = {
                         ...existingTransfer,
                         progress: data.progress,
                         size: data.total || existingTransfer.size,
-                        // Если это папка, мы не переходим в успех пока все файлы не закончатся,
-                        // но для простоты просто обновляем прогресс последнего файла.
-                        // Чтобы избежать краша с 3000 файлов, мы ищем по ID.
-                        status: data.progress >= 100 ? (data.id ? 'success' : 'success') : 'active'
+                        status: isFinished ? 'success' : 'active'
                     };
                     return newTransfers;
                 }
@@ -635,7 +634,7 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
                         const merged = [...files];
                         const currentDirTransfers = activeTransfers.filter(t =>
                             t.type === 'upload' &&
-                            t.status === 'active' &&
+                            (t.status === 'active' || t.status === 'success') &&
                             normalizeRemotePath(t.remotePath.substring(0, t.remotePath.lastIndexOf('/')) || '/') === normalizeRemotePath(path)
                         );
 

--- a/src/components/SFTPBrowser.tsx
+++ b/src/components/SFTPBrowser.tsx
@@ -439,13 +439,20 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
         const items = modal?.selectedFiles || (modal?.file ? [modal.file] : []);
         setIsProcessing(true);
         try {
+            const removedPaths: string[] = [];
             for (const file of items) {
+                const fullPath = `${path}/${file.filename}`.replace(/\/+/g, '/');
                 await ipcRenderer.invoke('sftp-rm', {
                     id,
-                    path: `${path}/${file.filename}`.replace(/\/+/g, '/'),
+                    path: fullPath,
                     isDir: (file.attrs.mode & 0o040000) !== 0
                 });
+                removedPaths.push(normalizeRemotePath(fullPath));
             }
+
+            // Удаляем удаленные файлы из списка задач, чтобы они исчезли из таблицы (через mergedFileList)
+            setActiveTransfers(prev => prev.filter(t => !removedPaths.includes(normalizeRemotePath(t.remotePath))));
+
             setModal(null);
             loadDirectory(path);
         } catch (err: unknown) {
@@ -459,11 +466,17 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
     const handleRename = async () => {
         if (!modal?.file || !modalInput) return;
         try {
+            const oldPath = `${path}/${modal.file.filename}`.replace(/\/+/g, '/');
             await ipcRenderer.invoke('sftp-rename', {
                 id,
-                oldPath: `${path}/${modal.file.filename}`.replace(/\/+/g, '/'),
+                oldPath,
                 newPath: `${path}/${modalInput}`.replace(/\/+/g, '/')
             });
+
+            // Очищаем старый путь из списка задач, чтобы избежать дубликатов или "фантомных" файлов при переименовании
+            const normalizedOldPath = normalizeRemotePath(oldPath);
+            setActiveTransfers(prev => prev.filter(t => normalizeRemotePath(t.remotePath) !== normalizedOldPath));
+
             setModal(null);
             loadDirectory(path);
         } catch (err: unknown) {

--- a/src/components/SFTPBrowser.tsx
+++ b/src/components/SFTPBrowser.tsx
@@ -105,10 +105,8 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
         try {
             const list = await ipcRenderer.invoke('sftp-readdir', {id, path: normalizedPath}) as SftpFileEntry[] | null;
 
-            // Очищаем успешно завершенные или отмененные трансферы при обновлении списка файлов,
-            // так как они уже должны быть видны в актуальном списке от сервера.
-            // Делаем это ПОСЛЕ получения данных, но перед отрисовкой, чтобы минимизировать зазор.
-            setActiveTransfers(prev => prev.filter(t => t.status === 'active'));
+            // Больше не удаляем успешно завершенные трансферы автоматически,
+            // чтобы пользователь видел историю операций в списке задач.
 
             let filteredList = (list || []).filter((f: SftpFileEntry) => !f.filename.startsWith('.'));
             filteredList.sort((a, b) => {

--- a/src/components/SFTPBrowser.tsx
+++ b/src/components/SFTPBrowser.tsx
@@ -329,10 +329,10 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
         }
     };
 
-    const handleUpload = async () => {
+    const handleUpload = async (mode: 'file' | 'folder') => {
         let newTransfersToUpdate: Transfer[] = [];
         try {
-            const selectedFiles = await ipcRenderer.invoke('sftp-select-files') as { path: string, name: string, size: number, isDir?: boolean }[] | null;
+            const selectedFiles = await ipcRenderer.invoke('sftp-select-files', mode) as { path: string, name: string, size: number, isDir?: boolean }[] | null;
             if (!selectedFiles || selectedFiles.length === 0) return;
 
             newTransfersToUpdate = selectedFiles.map(f => {

--- a/src/components/sftp/SftpModals.tsx
+++ b/src/components/sftp/SftpModals.tsx
@@ -164,17 +164,15 @@ export const SftpModals: React.FC<SftpModalsProps> = ({
                             <div style={{
                                 maxHeight: '150px',
                                 overflowY: 'auto',
-                                background: 'rgba(0,0,0,0.05)',
                                 padding: '10px',
                                 borderRadius: '8px',
-                                border: '1px solid var(--border-color)',
                                 display: 'flex',
                                 flexDirection: 'column',
                                 gap: '5px'
                             }}>
                                 {(modal.selectedFiles || (modal.file ? [modal.file] : [])).map(f => (
-                                    <div key={f.filename} style={{ wordBreak: 'break-all', fontSize: '0.9em', opacity: 0.8 }}>
-                                        • {f.filename}
+                                    <div key={f.filename} style={{ wordBreak: 'break-all', fontSize: '0.9em' }}>
+                                        {f.filename}
                                     </div>
                                 ))}
                             </div>
@@ -225,7 +223,7 @@ export const SftpModals: React.FC<SftpModalsProps> = ({
 
                                 {(['owner', 'group', 'others'] as const).map(role => (
                                     <div key={role} style={{ display: 'flex', alignItems: 'center', padding: '12px 0', borderBottom: '1px solid var(--border-color)' }}>
-                                        <div style={{ flex: 2, opacity: 0.8 }}>
+                                        <div style={{ flex: 2 }}>
                                             {role === 'owner' ? 'Владелец' : role === 'group' ? 'Группы' : 'Остальные'}
                                         </div>
                                         {(['read', 'write', 'execute'] as const).map(type => (

--- a/src/components/sftp/SftpModals.tsx
+++ b/src/components/sftp/SftpModals.tsx
@@ -171,7 +171,7 @@ export const SftpModals: React.FC<SftpModalsProps> = ({
                                 gap: '5px'
                             }}>
                                 {(modal.selectedFiles || (modal.file ? [modal.file] : [])).map(f => (
-                                    <div key={f.filename} style={{ wordBreak: 'break-all', fontSize: '0.9em' }}>
+                                    <div key={f.filename} style={{ wordBreak: 'break-all', fontSize: '1.1em' }}>
                                         {f.filename}
                                     </div>
                                 ))}
@@ -211,7 +211,7 @@ export const SftpModals: React.FC<SftpModalsProps> = ({
 
                     {modal.type === 'permissions' && permissions && (
                         <div style={{ display: 'flex', flexDirection: 'column', gap: '20px' }}>
-                            <div style={{ fontWeight: 'bold', fontSize: '0.9em', opacity: 0.9, wordBreak: 'break-all' }}>{modal.file?.filename}</div>
+                            <div style={{ fontWeight: 'bold', fontSize: '1.1em', opacity: 0.9, wordBreak: 'break-all' }}>{modal.file?.filename}</div>
 
                             <div>
                                 <div style={{ display: 'flex', borderBottom: '1px solid var(--border-color)', paddingBottom: '10px', marginBottom: '10px' }}>
@@ -242,7 +242,7 @@ export const SftpModals: React.FC<SftpModalsProps> = ({
                                 ))}
                             </div>
 
-                            <div style={{ display: 'flex', alignItems: 'center', gap: '10px', opacity: 1, fontSize: '0.9em' }}>
+                            <div style={{ display: 'flex', alignItems: 'center', gap: '10px', opacity: 1, fontSize: '1.1em' }}>
                                 Восьмеричный режим:
                                 <input
                                     value={modalInput}

--- a/src/components/sftp/SftpToolbar.tsx
+++ b/src/components/sftp/SftpToolbar.tsx
@@ -70,35 +70,15 @@ export const SftpToolbar: React.FC<SftpToolbarProps> = ({
                 }}>Release Candidate</span>
                 {path}
             </div>
-            <div style={{ display: 'flex', gap: '5px' }}>
-                <button
-                    onClick={() => onUpload('file')}
-                    disabled={loading}
-                    className="btn-primary"
-                    style={{ padding: '5px 15px', display: 'flex', alignItems: 'center', gap: '8px', borderRadius: '10px' }}
-                >
-                    <Upload size={18} />
-                    Файлы
-                </button>
-                <button
-                    onClick={() => onUpload('folder')}
-                    disabled={loading}
-                    className="btn-primary"
-                    style={{
-                        padding: '5px 15px',
-                        display: 'flex',
-                        alignItems: 'center',
-                        gap: '8px',
-                        borderRadius: '10px',
-                        background: 'var(--card-bg)',
-                        color: 'var(--text-color)',
-                        border: '1px solid var(--border-color)'
-                    }}
-                >
-                    <Upload size={18} />
-                    Папка
-                </button>
-            </div>
+            <button
+                onClick={() => onUpload('file')}
+                disabled={loading}
+                className="btn-primary"
+                style={{ padding: '5px 15px', display: 'flex', alignItems: 'center', gap: '8px', borderRadius: '10px' }}
+            >
+                <Upload size={18} />
+                Загрузить
+            </button>
         </div>
     );
 };

--- a/src/components/sftp/SftpToolbar.tsx
+++ b/src/components/sftp/SftpToolbar.tsx
@@ -7,7 +7,7 @@ interface SftpToolbarProps {
     primaryRed: string;
     onGoHome: () => void;
     onRefresh: () => void;
-    onUpload: () => void;
+    onUpload: (mode: 'file' | 'folder') => void;
 }
 
 export const SftpToolbar: React.FC<SftpToolbarProps> = ({
@@ -70,15 +70,35 @@ export const SftpToolbar: React.FC<SftpToolbarProps> = ({
                 }}>Release Candidate</span>
                 {path}
             </div>
-            <button
-                onClick={onUpload}
-                disabled={loading}
-                className="btn-primary"
-                style={{ padding: '5px 15px', display: 'flex', alignItems: 'center', gap: '8px', borderRadius: '10px' }}
-            >
-                <Upload size={18} />
-                Загрузить
-            </button>
+            <div style={{ display: 'flex', gap: '5px' }}>
+                <button
+                    onClick={() => onUpload('file')}
+                    disabled={loading}
+                    className="btn-primary"
+                    style={{ padding: '5px 15px', display: 'flex', alignItems: 'center', gap: '8px', borderRadius: '10px' }}
+                >
+                    <Upload size={18} />
+                    Файлы
+                </button>
+                <button
+                    onClick={() => onUpload('folder')}
+                    disabled={loading}
+                    className="btn-primary"
+                    style={{
+                        padding: '5px 15px',
+                        display: 'flex',
+                        alignItems: 'center',
+                        gap: '8px',
+                        borderRadius: '10px',
+                        background: 'var(--card-bg)',
+                        color: 'var(--text-color)',
+                        border: '1px solid var(--border-color)'
+                    }}
+                >
+                    <Upload size={18} />
+                    Папка
+                </button>
+            </div>
         </div>
     );
 };

--- a/src/components/sftp/SftpTransferPanel.tsx
+++ b/src/components/sftp/SftpTransferPanel.tsx
@@ -103,7 +103,7 @@ export const SftpTransferPanel: React.FC<SftpTransferPanelProps> = ({
                                 </div>
                                 <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: '4px' }}>
                                     <span style={{ fontSize: '10px', opacity: 0.7 }}>
-                                        {transfer.size ? formatSize(transfer.size) : '--'}
+                                        {typeof transfer.size === 'number' ? formatSize(transfer.size) : '--'}
                                     </span>
                                     <span style={{ fontSize: '10px', opacity: 0.7 }}>
                                         {transfer.status === 'active' ? 'В процессе...' : transfer.status === 'success' ? 'Успешно' : 'Ошибка'}

--- a/src/types.ts
+++ b/src/types.ts
@@ -55,6 +55,7 @@ export interface SftpFileEntry {
 }
 
 export interface SftpProgress {
+    id: string;
     remotePath: string;
     progress: number;
     transferred?: number;


### PR DESCRIPTION
Этот PR устраняет проблему «мерцания» интерфейса SFTP при загрузке папок. 

Ранее, при загрузке папки с множеством файлов, завершение загрузки каждого отдельного файла внутри папки приводило к установке статуса всей операции в `success`, из-за чего папка на мгновение исчезала из списка активных трансферов (и, следовательно, из списка файлов), а затем снова появлялась при начале загрузки следующего файла.

Изменения:
1. **SFTPBrowser.tsx**: Обработчик прогресса теперь переключает статус в `success` только в том случае, если завершилась загрузка именно того объекта (пути), который был инициализирован как основной трансфер.
2. **SFTPBrowser.tsx**: Список файлов теперь включает не только активные (`active`), но и успешно завершенные (`success`) трансферы в режиме оптимистичного отображения. Это гарантирует, что элемент не исчезнет из списка в промежутке между окончанием загрузки и обновлением данных от сервера.

---
*PR created automatically by Jules for task [6683764027991243097](https://jules.google.com/task/6683764027991243097) started by @megoRU*