### PR TITLE
Реализация агрегированного прогресса для папок в SFTP

### DIFF
--- a/electron/src/ipc-handlers.ts
+++ b/electron/src/ipc-handlers.ts
@@ -224,6 +224,34 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
         }
     })
 
+    /**
+     * Рекурсивно вычисляет суммарный размер файлов в удаленной папке.
+     */
+    async function getRemoteFolderSize(sftp: SFTPWrapper, remotePath: string): Promise<number> {
+        let size = 0
+        return new Promise((resolve) => {
+            sftp.readdir(remotePath, async (err, list) => {
+                if (err) return resolve(0)
+                try {
+                    for (const item of list) {
+                        if (item.filename === '.' || item.filename === '..') continue
+                        const itemPath = `${remotePath}/${item.filename}`.replace(/\/+/g, '/')
+                        const isDir = (item.attrs.mode & 0o170000) === 0o040000
+                        if (isDir) {
+                            size += await getRemoteFolderSize(sftp, itemPath)
+                        } else {
+                            size += item.attrs.size
+                        }
+                    }
+                    resolve(size)
+                } catch (e) {
+                    console.error(`[SFTP] Error calculating remote folder size for ${remotePath}:`, e)
+                    resolve(size)
+                }
+            })
+        })
+    }
+
     ipcMain.on('ssh-get-os-info', (event: IpcMainEvent, id: string) => {
         const client = sshClients.get(id)
         if (client) {
@@ -428,7 +456,14 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
         })
     })
 
-    async function downloadRecursive(id: string, remote: string, local: string, sftpOverride?: SFTPWrapper, transferId: string = 'internal'): Promise<SftpDownloadResult | undefined> {
+    async function downloadRecursive(
+        id: string,
+        remote: string,
+        local: string,
+        sftpOverride?: SFTPWrapper,
+        transferId: string = 'internal',
+        state?: { transferred: number; total: number; rootPath: string }
+    ): Promise<SftpDownloadResult | undefined> {
         const sftp = sftpOverride || sftpClients.get(id)
         if (!sftp) return undefined
 
@@ -442,7 +477,7 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
                     if (!fs.existsSync(local)) fs.mkdirSync(local, { recursive: true })
 
                     const win = getMainWindow()
-                    if (win) {
+                    if (win && !state) {
                         const progress: SftpProgress = { id: transferId, remotePath: normalizedRemote, progress: 0, type: 'download' }
                         win.webContents.send(`sftp-progress-${id}`, progress)
                     }
@@ -453,9 +488,9 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
                             for (const item of list) {
                                 if (item.filename === '.' || item.filename === '..') continue
                                 if (transferId !== 'internal' && !sftpTransferClients.has(transferId) && sftpOverride) break;
-                                await downloadRecursive(id, `${normalizedRemote}/${item.filename}`, path.join(local, item.filename), sftp, transferId)
+                                await downloadRecursive(id, `${normalizedRemote}/${item.filename}`, path.join(local, item.filename), sftp, transferId, state)
                             }
-                            if (win) {
+                            if (win && !state) {
                                 const progress: SftpProgress = { id: transferId, remotePath: normalizedRemote, progress: 100, type: 'download' }
                                 win.webContents.send(`sftp-progress-${id}`, progress)
                             }
@@ -466,17 +501,31 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
                     })
                 } else {
                     let lastProgressTime = 0
+                    let lastIndividualTransferred = 0
+
                     sftp.fastGet(normalizedRemote, local, {
                         step: (transferred, _chunk, total) => {
                             if (transferId !== 'internal' && !sftpTransferClients.has(transferId) && sftpOverride) return;
+
+                            if (state) {
+                                state.transferred += (transferred - lastIndividualTransferred)
+                                lastIndividualTransferred = transferred
+                            }
+
                             const now = Date.now()
                             if (now - lastProgressTime > 100 || transferred === total) {
                                 lastProgressTime = now
-                                const progress = Math.round((transferred / total) * 100)
                                 const win = getMainWindow()
                                 if (win) {
-                                    const progressData: SftpProgress = { id: transferId, remotePath: normalizedRemote, progress, transferred, total, type: 'download' }
-                                    win.webContents.send(`sftp-progress-${id}`, progressData)
+                                    if (state) {
+                                        const progress = state.total > 0 ? Math.min(Math.round((state.transferred / state.total) * 100), 100) : 100
+                                        const progressData: SftpProgress = { id: transferId, remotePath: state.rootPath, progress, transferred: state.transferred, total: state.total, type: 'download' }
+                                        win.webContents.send(`sftp-progress-${id}`, progressData)
+                                    } else {
+                                        const progress = Math.round((transferred / total) * 100)
+                                        const progressData: SftpProgress = { id: transferId, remotePath: normalizedRemote, progress, transferred, total, type: 'download' }
+                                        win.webContents.send(`sftp-progress-${id}`, progressData)
+                                    }
                                 }
                             }
                         }
@@ -492,18 +541,31 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
                                     return;
                                 }
                                 transferred += chunk.length
+                                if (state) {
+                                    state.transferred += chunk.length
+                                }
+
                                 const now = Date.now()
                                 if (now - lastProgressTime > 100 || transferred === stats.size) {
                                     lastProgressTime = now
-                                    const progress = Math.round((transferred / stats.size) * 100)
                                     const win = getMainWindow()
-                                    if (win) win.webContents.send(`sftp-progress-${id}`, { id: transferId, remotePath: normalizedRemote, progress, transferred, total: stats.size, type: 'download' })
+                                    if (win) {
+                                        if (state) {
+                                            const progress = state.total > 0 ? Math.min(Math.round((state.transferred / state.total) * 100), 100) : 100
+                                            win.webContents.send(`sftp-progress-${id}`, { id: transferId, remotePath: state.rootPath, progress, transferred: state.transferred, total: state.total, type: 'download' })
+                                        } else {
+                                            const progress = Math.round((transferred / stats.size) * 100)
+                                            win.webContents.send(`sftp-progress-${id}`, { id: transferId, remotePath: normalizedRemote, progress, transferred, total: stats.size, type: 'download' })
+                                        }
+                                    }
                                 }
                             })
 
                             writeStream.on('close', () => {
-                                const win = getMainWindow()
-                                if (win) win.webContents.send(`sftp-progress-${id}`, { id: transferId, remotePath: normalizedRemote, progress: 100, type: 'download' })
+                                if (!state) {
+                                    const win = getMainWindow()
+                                    if (win) win.webContents.send(`sftp-progress-${id}`, { id: transferId, remotePath: normalizedRemote, progress: 100, type: 'download' })
+                                }
                                 resolve({ remotePath: normalizedRemote, localPath: local, size: stats.size })
                             })
                             writeStream.on('error', (e) => {
@@ -514,10 +576,12 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
                             readStream.pipe(writeStream)
                         }
                         else {
-                            const win = getMainWindow()
-                            if (win) {
-                                const progressData: SftpProgress = { id: transferId, remotePath: normalizedRemote, progress: 100, type: 'download' }
-                                win.webContents.send(`sftp-progress-${id}`, progressData)
+                            if (!state) {
+                                const win = getMainWindow()
+                                if (win) {
+                                    const progressData: SftpProgress = { id: transferId, remotePath: normalizedRemote, progress: 100, type: 'download' }
+                                    win.webContents.send(`sftp-progress-${id}`, progressData)
+                                }
                             }
                             resolve({ remotePath: normalizedRemote, localPath: local, size: stats.size })
                         }
@@ -551,9 +615,24 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
             if (file.transferId) sftpTransferClients.set(file.transferId, sftp);
 
             const localPath = path.join(destDir, file.filename)
-            const result = await downloadRecursive(id, file.remotePath, localPath, sftp, file.transferId)
 
-            if (file.transferId) sftpTransferClients.delete(file.transferId);
+            let state: { transferred: number; total: number; rootPath: string } | undefined
+            if (file.isDir) {
+                const totalSize = await getRemoteFolderSize(sftp, file.remotePath)
+                state = { transferred: 0, total: totalSize, rootPath: file.remotePath }
+            }
+
+            const result = await downloadRecursive(id, file.remotePath, localPath, sftp, file.transferId, state)
+
+            if (file.transferId) {
+                sftpTransferClients.delete(file.transferId);
+                if (state) {
+                    const win = getMainWindow()
+                    if (win) {
+                        win.webContents.send(`sftp-progress-${id}`, { id: file.transferId, remotePath: file.remotePath, progress: 100, type: 'download' })
+                    }
+                }
+            }
             sftp.end();
             results.push(result)
         }
@@ -629,7 +708,24 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
         if (transferId) sftpTransferClients.set(transferId, sftp);
 
         try {
-            return await downloadRecursive(id, remotePath, filePath, sftp, transferId)
+            const stats = await new Promise<SftpFileEntry['attrs']>((res, rej) => sftp.stat(remotePath, (e, s) => e ? rej(e) : res(s)))
+            const isDir = (stats.mode & 0o170000) === 0o040000
+
+            let state: { transferred: number; total: number; rootPath: string } | undefined
+            if (isDir) {
+                const totalSize = await getRemoteFolderSize(sftp, remotePath)
+                state = { transferred: 0, total: totalSize, rootPath: remotePath }
+            }
+
+            const result = await downloadRecursive(id, remotePath, filePath, sftp, transferId, state)
+
+            if (state) {
+                const win = getMainWindow()
+                if (win) {
+                    win.webContents.send(`sftp-progress-${id}`, { id: transferId, remotePath: remotePath, progress: 100, type: 'download' })
+                }
+            }
+            return result
         } finally {
             if (transferId) sftpTransferClients.delete(transferId);
             sftp.end();
@@ -727,14 +823,20 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
         const client = sshClients.get(id)
         if (!client) return null
 
-        const uploadRecursive = async (local: string, remote: string, sftp: SFTPWrapper, transferId: string): Promise<SftpUploadResult> => {
+        const uploadRecursive = async (
+            local: string,
+            remote: string,
+            sftp: SFTPWrapper,
+            transferId: string,
+            state?: { transferred: number; total: number; rootPath: string }
+        ): Promise<SftpUploadResult> => {
             const normalizedRemote = normalizeRemotePath(remote)
             const stats = fs.statSync(local)
             if (stats.isDirectory()) {
                 await new Promise((resolve) => sftp.mkdir(normalizedRemote, () => resolve(true)))
 
                 const win = getMainWindow()
-                if (win) {
+                if (win && !state) {
                     const progress: SftpProgress = { id: transferId, remotePath: normalizedRemote, progress: 0, type: 'upload' }
                     win.webContents.send(`sftp-progress-${id}`, progress)
                 }
@@ -743,28 +845,42 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
                 const items: SftpUploadResult[] = []
                 for (const file of files) {
                     if (!sftpTransferClients.has(transferId)) break;
-                    items.push(await uploadRecursive(path.join(local, file), `${normalizedRemote}/${file}`, sftp, transferId))
+                    items.push(await uploadRecursive(path.join(local, file), `${normalizedRemote}/${file}`, sftp, transferId, state))
                 }
 
-                if (win) {
+                if (win && !state) {
                     const progress: SftpProgress = { id: transferId, remotePath: normalizedRemote, progress: 100, type: 'upload' }
                     win.webContents.send(`sftp-progress-${id}`, progress)
                 }
                 return { remotePath: normalizedRemote, isDir: true, items }
             } else {
                 let lastProgressTime = 0
+                let lastIndividualTransferred = 0
+
                 return new Promise((resolve, reject) => {
                     sftp.fastPut(local, normalizedRemote, {
                         step: (transferred, _chunk, total) => {
                             if (!sftpTransferClients.has(transferId)) return;
+
+                            if (state) {
+                                state.transferred += (transferred - lastIndividualTransferred)
+                                lastIndividualTransferred = transferred
+                            }
+
                             const now = Date.now()
                             if (now - lastProgressTime > 100 || transferred === total) {
                                 lastProgressTime = now
-                                const progress = Math.round((transferred / total) * 100)
                                 const win = getMainWindow()
                                 if (win) {
-                                    const progressData: SftpProgress = { id: transferId, remotePath: normalizedRemote, progress, transferred, total, type: 'upload' }
-                                    win.webContents.send(`sftp-progress-${id}`, progressData)
+                                    if (state) {
+                                        const progress = state.total > 0 ? Math.min(Math.round((state.transferred / state.total) * 100), 100) : 100
+                                        const progressData: SftpProgress = { id: transferId, remotePath: state.rootPath, progress, transferred: state.transferred, total: state.total, type: 'upload' }
+                                        win.webContents.send(`sftp-progress-${id}`, progressData)
+                                    } else {
+                                        const progress = Math.round((transferred / total) * 100)
+                                        const progressData: SftpProgress = { id: transferId, remotePath: normalizedRemote, progress, transferred, total, type: 'upload' }
+                                        win.webContents.send(`sftp-progress-${id}`, progressData)
+                                    }
                                 }
                             }
                         }
@@ -777,10 +893,12 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
                                 reject(err)
                             }
                         } else {
-                            const win = getMainWindow()
-                            if (win) {
-                                const progressData: SftpProgress = { id: transferId, remotePath: normalizedRemote, progress: 100, type: 'upload' }
-                                win.webContents.send(`sftp-progress-${id}`, progressData)
+                            if (!state) {
+                                const win = getMainWindow()
+                                if (win) {
+                                    const progressData: SftpProgress = { id: transferId, remotePath: normalizedRemote, progress: 100, type: 'upload' }
+                                    win.webContents.send(`sftp-progress-${id}`, progressData)
+                                }
                             }
                             resolve({ remotePath: normalizedRemote, size: stats.size })
                         }
@@ -802,7 +920,21 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
             })
             sftpTransferClients.set(transfer.transferId, sftp);
 
-            const res = await uploadRecursive(transfer.localPath, remotePath, sftp, transfer.transferId)
+            const stats = fs.statSync(transfer.localPath)
+            let state: { transferred: number; total: number; rootPath: string } | undefined
+            if (stats.isDirectory()) {
+                const totalSize = getFolderSize(transfer.localPath)
+                state = { transferred: 0, total: totalSize, rootPath: remotePath }
+            }
+
+            const res = await uploadRecursive(transfer.localPath, remotePath, sftp, transfer.transferId, state)
+
+            if (state) {
+                const win = getMainWindow()
+                if (win) {
+                    win.webContents.send(`sftp-progress-${id}`, { id: transfer.transferId, remotePath: remotePath, progress: 100, type: 'upload' })
+                }
+            }
 
             sftpTransferClients.delete(transfer.transferId);
             sftp.end();

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yetanothersshclient",
   "private": true,
-  "version": "1.5.6",
+  "version": "1.6.0",
   "description": "A modern multi-platform SSH client built with React and Electron",
   "repository": {
     "type": "git",

--- a/src/App.css
+++ b/src/App.css
@@ -326,6 +326,15 @@ body.gruvbox-light ::-webkit-scrollbar-thumb:hover {
 }
 
 /* Loading Spinner */
+.breadcrumb-container::-webkit-scrollbar {
+  display: none;
+}
+
+.breadcrumb-item:hover {
+  background: rgba(0, 0, 0, 0.05) !important;
+  border: 1px solid var(--border-color) !important;
+}
+
 .loading-spinner {
     width: 30px;
     height: 30px;

--- a/src/components/SFTPBrowser.tsx
+++ b/src/components/SFTPBrowser.tsx
@@ -244,13 +244,12 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
                             const newProgress = pathMatches ? d.progress : t.progress;
                             const newStatus = isFinished ? 'success' : 'active';
 
-                            if (t.progress !== newProgress || t.status !== newStatus) {
+                            if (t.progress !== newProgress || t.status !== newStatus || (pathMatches && d.total !== undefined && t.size !== d.total)) {
                                 next[idx] = {
                                     ...t,
                                     progress: newProgress,
-                                    // Для папок сохраняем ранее вычисленный рекурсивный размер,
-                                    // чтобы он не перезаписывался размером отдельного вложенного файла
-                                    size: t.isDir ? t.size : (pathMatches ? (d.total || t.size) : t.size),
+                                    // Если пришло значение d.total, обновляем размер (особенно важно для папок)
+                                    size: pathMatches ? (d.total ?? t.size) : t.size,
                                     status: newStatus as "active" | "success"
                                 };
                                 changed = true;
@@ -305,6 +304,8 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
             cancelledPathsRef.current.delete(`download:${remotePath}`);
             const transferId = Math.random().toString(36).substr(2, 9);
             cancelledTransferIdsRef.current.delete(transferId);
+            const isDir = file ? (file.attrs.mode & 0o170000) === 0o040000 : false;
+
             return {
                 id: transferId,
                 filename,
@@ -312,7 +313,8 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
                 progress: 0,
                 size: file?.attrs.size,
                 type: 'download',
-                status: 'active' as const
+                status: 'active' as const,
+                isDir
             };
         });
         setActiveTransfers(prev => [...newTransfers, ...prev]);

--- a/src/components/SFTPBrowser.tsx
+++ b/src/components/SFTPBrowser.tsx
@@ -725,7 +725,7 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig}
                         </div>
                     </div>
                 )}
-                <SftpToolbar path={path} loading={loading} primaryRed={primaryRed} onGoHome={handleGoHome} onRefresh={handleRefresh} onUpload={handleUpload}/>
+                <SftpToolbar path={path} loading={loading} onGoHome={handleGoHome} onRefresh={handleRefresh} onUpload={handleUpload} onNavigate={loadDirectory}/>
 
                 <div className="sftp-content"
                      onContextMenu={(e) => {

--- a/src/components/sftp/SftpToolbar.tsx
+++ b/src/components/sftp/SftpToolbar.tsx
@@ -31,7 +31,7 @@ export const SftpToolbar: React.FC<SftpToolbarProps> = React.memo(({
 
     return (
         <div className="sftp-toolbar" style={{
-            padding: '10px',
+            padding: '10.2px',
             borderBottom: '1px solid var(--border-color)',
             display: 'flex',
             alignItems: 'center',

--- a/src/components/sftp/SftpToolbar.tsx
+++ b/src/components/sftp/SftpToolbar.tsx
@@ -58,9 +58,6 @@ export const SftpToolbar: React.FC<SftpToolbarProps> = React.memo(({
             </button>
             <div style={{
                 flex: 1,
-                background: 'var(--input-bg)',
-                border: '1px solid var(--border-color)',
-                borderRadius: '4px',
                 padding: '0 10px',
                 height: '32px',
                 fontSize: '14px',
@@ -83,7 +80,7 @@ export const SftpToolbar: React.FC<SftpToolbarProps> = React.memo(({
                                     padding: '2px 6px',
                                     borderRadius: '4px',
                                     cursor: isLast ? 'default' : 'pointer',
-                                    opacity: isLast ? 0.7 : 1,
+                                    opacity: 1,
                                     fontWeight: isLast ? 'bold' : 'normal',
                                     transition: 'all 0.2s ease',
                                     display: 'flex',

--- a/src/components/sftp/SftpToolbar.tsx
+++ b/src/components/sftp/SftpToolbar.tsx
@@ -20,7 +20,7 @@ export const SftpToolbar: React.FC<SftpToolbarProps> = React.memo(({
 }) => {
     const breadcrumbs = useMemo(() => {
         const parts = path.split('/').filter(Boolean);
-        const crumbs = [{ name: 'root', path: '/' }];
+        const crumbs = [{ name: '/', path: '/' }];
         let currentPath = '';
         for (const part of parts) {
             currentPath += `/${part}`;

--- a/src/components/sftp/SftpToolbar.tsx
+++ b/src/components/sftp/SftpToolbar.tsx
@@ -1,23 +1,34 @@
-import React from 'react';
-import { Home, RefreshCw, Upload } from 'lucide-react';
+import React, { useMemo } from 'react';
+import { Home, RefreshCw, Upload, ChevronRight } from 'lucide-react';
 
 interface SftpToolbarProps {
     path: string;
     loading: boolean;
-    primaryRed: string;
     onGoHome: () => void;
     onRefresh: () => void;
     onUpload: (mode: 'file' | 'folder') => void;
+    onNavigate: (path: string) => void;
 }
 
 export const SftpToolbar: React.FC<SftpToolbarProps> = React.memo(({
     path,
     loading,
-    primaryRed,
     onGoHome,
     onRefresh,
-    onUpload
+    onUpload,
+    onNavigate
 }) => {
+    const breadcrumbs = useMemo(() => {
+        const parts = path.split('/').filter(Boolean);
+        const crumbs = [{ name: 'root', path: '/' }];
+        let currentPath = '';
+        for (const part of parts) {
+            currentPath += `/${part}`;
+            crumbs.push({ name: part, path: currentPath });
+        }
+        return crumbs;
+    }, [path]);
+
     return (
         <div className="sftp-toolbar" style={{
             padding: '10px',
@@ -50,25 +61,43 @@ export const SftpToolbar: React.FC<SftpToolbarProps> = React.memo(({
                 background: 'var(--input-bg)',
                 border: '1px solid var(--border-color)',
                 borderRadius: '4px',
-                padding: '5px 10px',
+                padding: '0 10px',
+                height: '32px',
                 fontSize: '14px',
                 display: 'flex',
                 alignItems: 'center',
-                overflow: 'hidden',
+                overflowX: 'auto',
+                overflowY: 'hidden',
                 whiteSpace: 'nowrap',
-                textOverflow: 'ellipsis',
-                gap: '10px'
-            }}>
-                <span style={{
-                    background: primaryRed,
-                    color: 'white',
-                    fontSize: '10px',
-                    padding: '1px 5px',
-                    borderRadius: '4px',
-                    fontWeight: 'bold',
-                    flexShrink: 0
-                }}>Release Candidate</span>
-                {path}
+                gap: '4px',
+                scrollbarWidth: 'none' // Hide scrollbar for cleaner look
+            }} className="breadcrumb-container">
+                {breadcrumbs.map((crumb, idx) => {
+                    const isLast = idx === breadcrumbs.length - 1;
+                    return (
+                        <React.Fragment key={crumb.path}>
+                            {idx > 0 && <ChevronRight size={14} style={{ opacity: 0.5, flexShrink: 0 }} />}
+                            <div
+                                onClick={() => !isLast && onNavigate(crumb.path)}
+                                style={{
+                                    padding: '2px 6px',
+                                    borderRadius: '4px',
+                                    cursor: isLast ? 'default' : 'pointer',
+                                    opacity: isLast ? 0.7 : 1,
+                                    fontWeight: isLast ? 'bold' : 'normal',
+                                    transition: 'all 0.2s ease',
+                                    display: 'flex',
+                                    alignItems: 'center',
+                                    background: 'transparent',
+                                    border: '1px solid transparent'
+                                }}
+                                className={!isLast ? "breadcrumb-item" : ""}
+                            >
+                                {crumb.name}
+                            </div>
+                        </React.Fragment>
+                    );
+                })}
             </div>
             <button
                 onClick={() => onUpload('file')}

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,7 +101,7 @@ export interface Transfer {
 
 export type NotificationType = 'success' | 'error' | 'info';
 
-export const VERSION = '1.5.6';
+export const VERSION = '1.6.0';
 
 export interface SftpDownloadResult {
     remotePath: string;


### PR DESCRIPTION
Реализовано отображение промежуточного прогресса при загрузке и скачивании папок через SFTP. Вместо простого переключения 0/100% теперь рассчитывается процент завершения на основе общего объема всех файлов в папке (в байтах). 

Основные изменения:
- В `electron/src/ipc-handlers.ts` добавлена асинхронная функция `getRemoteFolderSize` для вычисления размера удаленных папок.
- Функции `downloadRecursive` и `uploadRecursive` теперь принимают объект состояния для отслеживания суммарного прогресса.
- В `SFTPBrowser.tsx` добавлена корректная инициализация флага `isDir` и обновление размера задачи в реальном времени.

---
*PR created automatically by Jules for task [15463094396596742126](https://jules.google.com/task/15463094396596742126) started by @megoRU*