### PR TITLE
Замена xterm.js на кастомный Canvas-терминал

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,6 @@
       "name": "yetanothersshclient",
       "version": "1.6.1",
       "dependencies": {
-        "@xterm/addon-clipboard": "^0.2.0",
-        "@xterm/addon-fit": "^0.11.0",
-        "@xterm/addon-webgl": "^0.19.0",
-        "@xterm/xterm": "^6.0.0",
         "electron-updater": "^6.8.3",
         "lucide-react": "^0.575.0",
         "os-browserify": "^0.3.0",
@@ -2647,36 +2643,6 @@
       "engines": {
         "node": ">=10.0.0"
       }
-    },
-    "node_modules/@xterm/addon-clipboard": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@xterm/addon-clipboard/-/addon-clipboard-0.2.0.tgz",
-      "integrity": "sha512-Dl31BCtBhLaUEECUbEiVcCLvLBbaeGYdT7NofB8OJkGTD3MWgBsaLjXvfGAD4tQNHhm6mbKyYkR7XD8kiZsdNg==",
-      "license": "MIT",
-      "dependencies": {
-        "js-base64": "^3.7.5"
-      }
-    },
-    "node_modules/@xterm/addon-fit": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
-      "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
-      "license": "MIT"
-    },
-    "node_modules/@xterm/addon-webgl": {
-      "version": "0.19.0",
-      "resolved": "https://registry.npmjs.org/@xterm/addon-webgl/-/addon-webgl-0.19.0.tgz",
-      "integrity": "sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A==",
-      "license": "MIT"
-    },
-    "node_modules/@xterm/xterm": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@xterm/xterm/-/xterm-6.0.0.tgz",
-      "integrity": "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg==",
-      "license": "MIT",
-      "workspaces": [
-        "addons/*"
-      ]
     },
     "node_modules/7zip-bin": {
       "version": "5.2.0",
@@ -5705,12 +5671,6 @@
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }
-    },
-    "node_modules/js-base64": {
-      "version": "3.7.8",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-3.7.8.tgz",
-      "integrity": "sha512-hNngCeKxIUQiEUN3GPJOkz4wF/YvdUdbNL9hsBcMQTkKzboD7T/q3OYOuuPZLUE6dBxSGpwhk5mwuDud7JVAow==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -23,10 +23,6 @@
     "package:win:arm64": "npm run build && electron-builder --win nsis --arm64"
   },
   "dependencies": {
-    "@xterm/addon-clipboard": "^0.2.0",
-    "@xterm/addon-fit": "^0.11.0",
-    "@xterm/addon-webgl": "^0.19.0",
-    "@xterm/xterm": "^6.0.0",
     "electron-updater": "^6.8.3",
     "lucide-react": "^0.575.0",
     "os-browserify": "^0.3.0",

--- a/src/App.css
+++ b/src/App.css
@@ -288,17 +288,6 @@ body.gruvbox-light ::-webkit-scrollbar-thumb:hover {
     background-color: rgba(60, 56, 54, 0.4) !important;
 }
 
-/* Specific fix for xterm viewport to ensure it's applied correctly */
-.xterm-viewport::-webkit-scrollbar {
-    width: 10px !important;
-}
-
-.xterm-viewport::-webkit-scrollbar-thumb {
-    border-radius: 10px !important;
-    border: 3px solid transparent !important;
-    background-clip: content-box !important;
-}
-
 /* SFTP Styles */
 .sftp-row {
     transition: background-color 0.2s;
@@ -669,11 +658,3 @@ input[type="number"] {
     to { opacity: 1; transform: scale(1); }
 }
 
-/* Xterm readiness visibility */
-.xterm {
-    visibility: hidden;
-}
-
-.xterm.xterm-ready {
-    visibility: visible;
-}

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -227,6 +227,8 @@ export const TerminalComponent: React.FC<Props> = ({
             const charCode = key.toLowerCase().charCodeAt(0);
             if (charCode >= 97 && charCode <= 122) {
                 data = String.fromCharCode(charCode - 96);
+            } else if (key === 'Enter') {
+                data = '\n';
             }
         } else {
             switch (key) {
@@ -270,21 +272,16 @@ export const TerminalComponent: React.FC<Props> = ({
     const isConnected = status === 'Установлено соединение';
 
     useEffect(() => {
-        if (isConnected && isReady) {
-            const timer = setTimeout(() => {
-                if (isMountedRef.current) {
+        const timer = setTimeout(() => {
+            if (isMountedRef.current) {
+                if (isConnected && isReady) {
                     setShowTerminal(true);
-                }
-            }, 150);
-            return () => clearTimeout(timer);
-        } else if (isFailed) {
-            const timer = setTimeout(() => {
-                if (isMountedRef.current) {
+                } else if (isFailed) {
                     setShowTerminal(false);
                 }
-            }, 0);
-            return () => clearTimeout(timer);
-        }
+            }
+        }, 0);
+        return () => clearTimeout(timer);
     }, [isConnected, isReady, isFailed]);
 
     const handleContextMenu = (e: React.MouseEvent) => {

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -43,7 +43,6 @@ export const TerminalComponent: React.FC<Props> = ({
     const [status, setStatus] = useState<string>('Соединение...');
     const [retryKey, setRetryKey] = useState<number>(0);
     const [isReady, setIsReady] = useState(false);
-    const [hasReceivedData, setHasReceivedData] = useState(false);
     const [showTerminal, setShowTerminal] = useState(false);
     const isMountedRef = useRef<boolean>(true);
     const wasConnectedRef = useRef<boolean>(false);
@@ -73,7 +72,6 @@ export const TerminalComponent: React.FC<Props> = ({
 
     const connect = useCallback((connId: string, cols?: number, rows?: number) => {
         setStatus('Соединение...');
-        setHasReceivedData(false);
         const finalCols = cols || terminalCore.cols || 80;
         const finalRows = rows || terminalCore.rows || 24;
         ipcRenderer.send('ssh-connect', { id: connId, config, cols: finalCols, rows: finalRows });
@@ -95,10 +93,18 @@ export const TerminalComponent: React.FC<Props> = ({
             ipcRenderer.send('ssh-input', { id: connId, data });
         });
 
+        const decoder = new TextDecoder();
+        const ipv4Regex = /\b(?:\d{1,3}\.){3}\d{1,3}\b/g;
+        const ipv6Regex = /(?:[a-fA-F0-9]{1,4}:){7}[a-fA-F0-9]{1,4}|(?:::(?:[a-fA-F0-9]{1,4}:){0,6}[a-fA-F0-9]{1,4}|(?:[a-fA-F0-9]{1,4}:){1,7}:)/g;
+
         const onOutput = (data: Uint8Array) => {
             if (isMountedRef.current) {
-                setHasReceivedData(true);
-                terminalCore.write(data);
+                // Colorize IPs using SGR foreground color 39 to reset color only
+                const text = decoder.decode(data, { stream: true });
+                const colorizedText = text.replace(ipv4Regex, (match) => `\x1b[38;2;210;84;154m${match}\x1b[39m`)
+                                         .replace(ipv6Regex, (match) => `\x1b[38;2;210;84;154m${match}\x1b[39m`);
+
+                terminalCore.write(colorizedText);
             }
         };
 
@@ -218,13 +224,10 @@ export const TerminalComponent: React.FC<Props> = ({
 
         let data = '';
         if (ctrlKey) {
-            if (key >= 'a' && key <= 'z') data = String.fromCharCode(key.charCodeAt(0) - 96);
-            else if (key === 'r') data = '\x12';
-            else if (key === 'c') data = '\x03';
-            else if (key === 'd') data = '\x04';
-            else if (key === 'l') data = '\x0c';
-            else if (key === 'u') data = '\x15';
-            else if (key === 'w') data = '\x17';
+            const charCode = key.toLowerCase().charCodeAt(0);
+            if (charCode >= 97 && charCode <= 122) {
+                data = String.fromCharCode(charCode - 96);
+            }
         } else {
             switch (key) {
                 case 'Enter': data = '\r'; break;
@@ -264,15 +267,17 @@ export const TerminalComponent: React.FC<Props> = ({
         }
     }, [status, handleCopy, handlePaste]);
 
+    const isConnected = status === 'Установлено соединение';
+
     useEffect(() => {
-        if (status === 'Установлено соединение' && hasReceivedData && isReady) {
+        if (isConnected && isReady) {
             const timer = setTimeout(() => {
                 if (isMountedRef.current) {
                     setShowTerminal(true);
                 }
             }, 150);
             return () => clearTimeout(timer);
-        } else {
+        } else if (isFailed) {
             const timer = setTimeout(() => {
                 if (isMountedRef.current) {
                     setShowTerminal(false);
@@ -280,7 +285,7 @@ export const TerminalComponent: React.FC<Props> = ({
             }, 0);
             return () => clearTimeout(timer);
         }
-    }, [status, hasReceivedData, isReady]);
+    }, [isConnected, isReady, isFailed]);
 
     const handleContextMenu = (e: React.MouseEvent) => {
         e.preventDefault();

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -269,7 +269,7 @@ export const TerminalComponent: React.FC<Props> = ({
         }
     }, [status, handleCopy, handlePaste]);
 
-    const isConnected = status === 'Установлено соединение';
+    const isConnected = status.toLowerCase().includes('установлено') || status.toLowerCase().includes('connected');
 
     useEffect(() => {
         const timer = setTimeout(() => {

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -1,13 +1,10 @@
-import React, { useEffect, useRef, useState, useCallback } from 'react';
-import { Terminal } from '@xterm/xterm';
-import { FitAddon } from '@xterm/addon-fit';
-import { ClipboardAddon } from '@xterm/addon-clipboard';
-import { WebglAddon } from '@xterm/addon-webgl';
+import React, { useEffect, useRef, useState, useCallback, useMemo } from 'react';
 import { Terminal as IconTerminal, Plug } from 'lucide-react';
-import { getXtermTheme } from '../utils/theme';
+import { getTerminalTheme } from '../utils/theme';
 import { getOSIcon } from '../utils';
 import type { SSHConfig } from '../types';
-import '@xterm/xterm/css/xterm.css';
+import { TerminalCore } from './terminal/TerminalCore';
+import { CanvasRenderer } from './terminal/CanvasRenderer';
 
 const { ipcRenderer } = window;
 
@@ -30,17 +27,18 @@ export const TerminalComponent: React.FC<Props> = ({
     config,
     terminalFontName,
     terminalFontSize,
-    terminalScrollSensitivity,
     visible,
     onOSInfo,
-    enableContextMenu,
     onEditConfig,
     onClose
 }) => {
-    const termRef = useRef<HTMLDivElement>(null);
-    const xtermRef = useRef<Terminal | null>(null);
-    const fitAddonRef = useRef<FitAddon | null>(null);
-    const safeFitTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+    const termTheme = useMemo(() => getTerminalTheme(theme), [theme]);
+    const [terminalCore] = useState(() => new TerminalCore(80, 24, termTheme));
+
+    useEffect(() => {
+        terminalCore.updateTheme(termTheme);
+    }, [termTheme, terminalCore]);
+
     const connIdRef = useRef<string | null>(null);
     const [status, setStatus] = useState<string>('Соединение...');
     const [retryKey, setRetryKey] = useState<number>(0);
@@ -50,6 +48,7 @@ export const TerminalComponent: React.FC<Props> = ({
     const isMountedRef = useRef<boolean>(true);
     const wasConnectedRef = useRef<boolean>(false);
     const [countdown, setCountdown] = useState<number | null>(null);
+    const [currentSelection, setCurrentSelection] = useState<{ startX: number, startY: number, endX: number, endY: number } | null>(null);
 
     // Вычисляемые свойства (Derived State)
     const isWaiting = !showTerminal;
@@ -71,173 +70,34 @@ export const TerminalComponent: React.FC<Props> = ({
     const onOSInfoRef = useRef(onOSInfo);
     useEffect(() => { onOSInfoRef.current = onOSInfo; }, [onOSInfo]);
 
-    const safeFit = useCallback((delay = 80) => {
-        if (isMountedRef.current && xtermRef.current && fitAddonRef.current && connIdRef.current && visible) {
-            if (safeFitTimeoutRef.current) {
-                clearTimeout(safeFitTimeoutRef.current);
-            }
-            if (delay === 0) {
-                try {
-                    fitAddonRef.current.fit();
-                    const {cols, rows} = xtermRef.current;
-                    if (cols > 0 && rows > 0) {
-                        ipcRenderer.send('ssh-resize', {id: connIdRef.current, cols, rows});
-                    }
-                } catch (err) {
-                    console.warn('[Terminal] fit() failed:', err);
-                }
-                return;
-            }
-            safeFitTimeoutRef.current = setTimeout(() => {
-                if (!isMountedRef.current || !xtermRef.current || !fitAddonRef.current || !visible) return;
-                try {
-                    fitAddonRef.current.fit();
-                    const {cols, rows} = xtermRef.current;
-                    if (cols > 0 && rows > 0) {
-                        ipcRenderer.send('ssh-resize', {id: connIdRef.current, cols, rows});
-                    }
-                } catch (err) {
-                    console.warn('[Terminal] fit() failed:', err);
-                }
-            }, delay);
-        }
-    }, [visible]);
-
     const connect = useCallback((connId: string, cols?: number, rows?: number) => {
-        if (!xtermRef.current) return;
         setStatus('Соединение...');
         setHasReceivedData(false);
-        // wasConnectedRef.current НЕ сбрасываем здесь, чтобы сохранить желание переподключаться
-        // при временных сбоях (например ECONNREFUSED во время перезагрузки сервера).
-        const finalCols = cols || xtermRef.current.cols || 80;
-        const finalRows = rows || xtermRef.current.rows || 24;
+        const finalCols = cols || terminalCore.cols || 80;
+        const finalRows = rows || terminalCore.rows || 24;
         ipcRenderer.send('ssh-connect', { id: connId, config, cols: finalCols, rows: finalRows });
-    }, [config]);
+    }, [config, terminalCore]);
+
+    const handleResize = useCallback((cols: number, rows: number) => {
+        if (connIdRef.current) {
+            ipcRenderer.send('ssh-resize', { id: connIdRef.current, cols, rows });
+        }
+    }, []);
 
     useEffect(() => {
-        if (!termRef.current) return;
-        let active = true;
-
-        setIsReady(false);
-
         const connId = Math.random().toString(36).substring(2, 15);
         connIdRef.current = connId;
         isMountedRef.current = true;
 
-        const term = new Terminal({
-            cursorBlink: true,
-            cursorStyle: 'block',
-            theme: getXtermTheme(theme),
-            fontFamily: "'" + terminalFontName + "', 'JetBrains Mono', monospace",
-            fontSize: terminalFontSize,
-            allowProposedApi: true,
-            lineHeight: 1,
-            letterSpacing: 0,
-            scrollback: 50000,
-            scrollSensitivity: terminalScrollSensitivity,
-        });
-
-        const fitAddon = new FitAddon();
-        const clipboardAddon = new ClipboardAddon();
-        term.loadAddon(fitAddon);
-        term.loadAddon(clipboardAddon);
-        term.open(termRef.current);
-
-        try {
-            const webglAddon = new WebglAddon();
-            term.loadAddon(webglAddon);
-        } catch (e) {
-            console.warn('WebGL addon could not be loaded, falling back to standard renderer', e);
-        }
-
-        xtermRef.current = term;
-        fitAddonRef.current = fitAddon;
-
-        const openTerminal = () => {
-            if (!active || !termRef.current) return;
-            term.open(termRef.current);
-
-            requestAnimationFrame(() => {
-                if (!active) return;
-                try {
-                    fitAddon.fit();
-                    const { cols, rows } = term;
-                    setIsReady(true);
-                    connect(connId, cols, rows);
-
-                    // Добавляем класс готовности для CSS
-                    term.element?.classList.add('xterm-ready');
-                } catch (e) {
-                    console.warn('[Terminal] Initial fit failed:', e);
-                    connect(connId);
-                    setIsReady(true);
-                }
-            });
-        };
-
-        const docWithFonts = document as unknown as { fonts?: { status: string, ready: Promise<void> } };
-        if (docWithFonts.fonts?.status === 'loaded') {
-            openTerminal();
-        } else if (docWithFonts.fonts) {
-            docWithFonts.fonts.ready.then(openTerminal);
-        } else {
-            openTerminal();
-        }
-
-        const resizeObserver = new ResizeObserver(() => {
-            if (isMountedRef.current) {
-                safeFit();
-            }
-        });
-        resizeObserver.observe(termRef.current);
-
-        term.onData(data => {
+        terminalCore.clear();
+        terminalCore.setInputCallback((data: string) => {
             ipcRenderer.send('ssh-input', { id: connId, data });
-        });
-
-        term.attachCustomKeyEventHandler((e) => {
-            if (e.type === 'keydown') {
-                const isMac = ipcRenderer.platform === 'darwin';
-                const isCopy = (isMac && e.metaKey && e.code === 'KeyC') || (e.ctrlKey && e.shiftKey && e.code === 'KeyC');
-                const isPaste = (isMac && e.metaKey && e.code === 'KeyV') || (e.ctrlKey && e.shiftKey && e.code === 'KeyV');
-
-                if (isCopy) {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    const selection = term.getSelection();
-                    if (selection) {
-                        navigator.clipboard.writeText(selection);
-                    }
-                    return false;
-                }
-
-                if (isPaste) {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    navigator.clipboard.readText().then(text => {
-                        if (text && isMountedRef.current) {
-                            term.paste(text);
-                        }
-                    });
-                    return false;
-                }
-
-                // Разрешаем Ctrl+R для поиска в истории терминала (reverse-i-search)
-                if (e.ctrlKey && e.code === 'KeyR') {
-                    return true;
-                }
-            }
-            return true;
         });
 
         const onOutput = (data: Uint8Array) => {
             if (isMountedRef.current) {
                 setHasReceivedData(true);
-                try {
-                    term.write(data);
-                } catch (err) {
-                    console.warn('[Terminal] write failed:', err);
-                }
+                terminalCore.write(data);
             }
         };
 
@@ -250,78 +110,46 @@ export const TerminalComponent: React.FC<Props> = ({
                 if (!config.osPrettyName) {
                     ipcRenderer.send('ssh-get-os-info', connId);
                 }
-                setTimeout(() => {
-                    if (isMountedRef.current) {
-                        term.focus();
-                        safeFit();
-                        setTimeout(safeFit, 100);
-                    }
-                }, 100);
             }
         };
 
         const onError = (data: string) => {
             if (isMountedRef.current) {
                 if (data.startsWith('AUTH_FAILURE:')) {
-                    wasConnectedRef.current = false; // При ошибке аутентификации сбрасываем, чтобы не было авто-реконнекта
+                    wasConnectedRef.current = false;
                 }
-                try {
-                    const cleanError = data.startsWith('AUTH_FAILURE:') ? data.replace('AUTH_FAILURE:', '').trim() : data;
-                    term.write(`\r\n\x1b[31mОшибка: ${cleanError}\x1b[0m\r\n`);
-                } catch { /* ignore */ }
+                const cleanError = data.startsWith('AUTH_FAILURE:') ? data.replace('AUTH_FAILURE:', '').trim() : data;
+                terminalCore.write(`\r\n\x1b[31mОшибка: ${cleanError}\x1b[0m\r\n`);
                 setStatus(data);
             }
         };
 
-        const unsubOutput = ipcRenderer.on(`ssh-output-${connId}`, (...args: unknown[]) => onOutput(args[0] as Uint8Array));
-        const unsubStatus = ipcRenderer.on(`ssh-status-${connId}`, (...args: unknown[]) => onStatus(args[0] as string));
-        const unsubError = ipcRenderer.on(`ssh-error-${connId}`, (...args: unknown[]) => onError(args[0] as string));
-        const unsubOSInfo = ipcRenderer.on(`ssh-os-info-${connId}`, (...args: unknown[]) => {
-            const info = args[0] as string;
-            if (isMountedRef.current && onOSInfoRef.current) onOSInfoRef.current(info);
-        });
+        // Listener registration
+        const listeners = [
+            ipcRenderer.on(`ssh-output-${connId}`, (_: unknown, data: Uint8Array) => onOutput(data)),
+            ipcRenderer.on(`ssh-status-${connId}`, (_: unknown, data: string) => onStatus(data)),
+            ipcRenderer.on(`ssh-error-${connId}`, (_: unknown, data: string) => onError(data)),
+            ipcRenderer.on(`ssh-os-info-${connId}`, (_: unknown, data: string) => {
+                if (isMountedRef.current && onOSInfoRef.current) onOSInfoRef.current(data);
+            })
+        ];
 
-        // connect(connId); // Теперь вызывается в pipeline выше после fit()
+        const timerId = setTimeout(() => {
+            if (isMountedRef.current) {
+                setIsReady(true);
+                connect(connId);
+            }
+        }, 0);
 
         return () => {
-            active = false;
             isMountedRef.current = false;
-            if (safeFitTimeoutRef.current) clearTimeout(safeFitTimeoutRef.current);
-            resizeObserver.disconnect();
+            clearTimeout(timerId);
             ipcRenderer.send('ssh-close', connId);
-            if (typeof unsubOutput === 'function') unsubOutput();
-            if (typeof unsubStatus === 'function') unsubStatus();
-            if (typeof unsubError === 'function') unsubError();
-            if (typeof unsubOSInfo === 'function') unsubOSInfo();
-            try {
-                term.dispose();
-            } catch { /* ignore */ }
+            listeners.forEach(unsub => {
+                if (typeof unsub === 'function') unsub();
+            });
         };
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [retryKey, config, connect]);
-
-    useEffect(() => {
-        if (xtermRef.current) {
-            xtermRef.current.options.theme = getXtermTheme(theme);
-            xtermRef.current.options.fontFamily = "'" + terminalFontName + "', 'JetBrains Mono', monospace";
-            xtermRef.current.options.fontSize = terminalFontSize;
-            xtermRef.current.options.lineHeight = 1;
-            xtermRef.current.options.letterSpacing = 0;
-            xtermRef.current.options.scrollSensitivity = terminalScrollSensitivity;
-            safeFit();
-        }
-    }, [theme, terminalFontName, terminalFontSize, terminalScrollSensitivity, safeFit]);
-
-    useEffect(() => {
-        if (visible && isMountedRef.current) {
-            safeFit();
-            setTimeout(() => {
-                if (isMountedRef.current && xtermRef.current) {
-                    xtermRef.current.focus();
-                }
-            }, 50);
-        }
-    }, [visible, safeFit]);
+    }, [retryKey, config, connect, terminalCore]);
 
     useEffect(() => {
         let timer: ReturnType<typeof setInterval> | undefined;
@@ -330,10 +158,9 @@ export const TerminalComponent: React.FC<Props> = ({
         const shouldRetry = (status === 'Соединение закрыто' || isErrorStatus) && wasConnectedRef.current && !isAuthFailed;
 
         if (shouldRetry) {
-            setCountdown(5);
             timer = setInterval(() => {
                 setCountdown(prev => {
-                    if (prev === null) return null;
+                    if (prev === null) return 5;
                     if (prev <= 1) {
                         clearInterval(timer);
                         setRetryKey(k => k + 1);
@@ -346,60 +173,126 @@ export const TerminalComponent: React.FC<Props> = ({
         return () => clearInterval(timer);
     }, [status, isAuthFailed]);
 
-    const handleContextMenu = (e: React.MouseEvent) => {
-        if (!enableContextMenu || !xtermRef.current) return;
-        e.preventDefault();
-
-        const term = xtermRef.current;
-        const selection = term.getSelection();
-
-        if (selection) {
-            // Если есть выделение - копируем и снимаем выделение
-            navigator.clipboard.writeText(selection);
-            term.clearSelection();
-        } else {
-            // Если выделения нет - вставляем из буфера
-            navigator.clipboard.readText().then(text => {
-                if (text && isMountedRef.current) {
-                    term.paste(text);
-                }
-            });
-        }
-    };
-
-    useEffect(() => {
-        const handleForceCtrlR = () => {
-            if (visible && connIdRef.current && status === 'Установлено соединение') {
-                console.log('[Terminal] Force sending Ctrl+R to SSH session');
-                ipcRenderer.send('ssh-input', { id: connIdRef.current, data: '\x12' });
+    const handlePaste = useCallback(async () => {
+        try {
+            const text = await navigator.clipboard.readText();
+            if (text && connIdRef.current && status === 'Установлено соединение') {
+                ipcRenderer.send('ssh-input', { id: connIdRef.current, data: text });
             }
-        };
+        } catch (err) {
+            console.error('Failed to paste:', err);
+        }
+    }, [status]);
 
-        window.addEventListener('terminal-force-ctrl-r', handleForceCtrlR);
-        return () => window.removeEventListener('terminal-force-ctrl-r', handleForceCtrlR);
-    }, [visible, status]);
+    const handleCopy = useCallback(() => {
+        if (currentSelection) {
+            const text = terminalCore.getSelectionText(currentSelection);
+            if (text) {
+                navigator.clipboard.writeText(text);
+                setCurrentSelection(null);
+            }
+        }
+    }, [currentSelection, terminalCore]);
+
+    const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+        if (!connIdRef.current || status !== 'Установлено соединение') return;
+
+        const { key, ctrlKey, shiftKey } = e;
+
+        // Support Ctrl+Shift+C/V for Copy/Paste as requested
+        if (ctrlKey && shiftKey) {
+            if (key.toLowerCase() === 'c') {
+                e.preventDefault();
+                handleCopy();
+                return;
+            }
+            if (key.toLowerCase() === 'v') {
+                e.preventDefault();
+                handlePaste();
+                return;
+            }
+        }
+
+        let data = '';
+        if (ctrlKey) {
+            if (key >= 'a' && key <= 'z') data = String.fromCharCode(key.charCodeAt(0) - 96);
+            else if (key === 'r') data = '\x12';
+            else if (key === 'c') data = '\x03';
+            else if (key === 'd') data = '\x04';
+            else if (key === 'l') data = '\x0c';
+            else if (key === 'u') data = '\x15';
+            else if (key === 'w') data = '\x17';
+        } else {
+            switch (key) {
+                case 'Enter': data = '\r'; break;
+                case 'Backspace': data = '\x7f'; break;
+                case 'Tab': e.preventDefault(); data = '\t'; break;
+                case 'Escape': data = '\x1b'; break;
+                case 'ArrowUp': data = '\x1b[A'; break;
+                case 'ArrowDown': data = '\x1b[B'; break;
+                case 'ArrowRight': data = '\x1b[C'; break;
+                case 'ArrowLeft': data = '\x1b[D'; break;
+                case 'Home': data = '\x1b[H'; break;
+                case 'End': data = '\x1b[F'; break;
+                case 'PageUp': data = '\x1b[5~'; break;
+                case 'PageDown': data = '\x1b[6~'; break;
+                case 'Insert': data = '\x1b[2~'; break;
+                case 'Delete': data = '\x1b[3~'; break;
+                case 'F1': data = '\x1bOP'; break;
+                case 'F2': data = '\x1bOQ'; break;
+                case 'F3': data = '\x1bOR'; break;
+                case 'F4': data = '\x1bOS'; break;
+                case 'F5': data = '\x1b[15~'; break;
+                case 'F6': data = '\x1b[17~'; break;
+                case 'F7': data = '\x1b[18~'; break;
+                case 'F8': data = '\x1b[19~'; break;
+                case 'F9': data = '\x1b[20~'; break;
+                case 'F10': data = '\x1b[21~'; break;
+                case 'F11': data = '\x1b[23~'; break;
+                case 'F12': data = '\x1b[24~'; break;
+                default:
+                    if (key.length === 1) data = key;
+                    break;
+            }
+        }
+
+        if (data) {
+             ipcRenderer.send('ssh-input', { id: connIdRef.current, data });
+        }
+    }, [status, handleCopy, handlePaste]);
 
     useEffect(() => {
         if (status === 'Установлено соединение' && hasReceivedData && isReady) {
             const timer = setTimeout(() => {
                 if (isMountedRef.current) {
                     setShowTerminal(true);
-                    // После показа терминала делаем ресайз, так как контейнер мог изменить размеры
-                    // из-за исчезновения оверлея
-                    setTimeout(() => safeFit(0), 10);
-                    setTimeout(() => safeFit(0), 100);
-                    setTimeout(safeFit, 400);
                 }
             }, 150);
             return () => clearTimeout(timer);
         } else {
-            setShowTerminal(false);
+            const timer = setTimeout(() => {
+                if (isMountedRef.current) {
+                    setShowTerminal(false);
+                }
+            }, 0);
+            return () => clearTimeout(timer);
         }
-    }, [status, hasReceivedData, isReady, safeFit]);
+    }, [status, hasReceivedData, isReady]);
+
+    const handleContextMenu = (e: React.MouseEvent) => {
+        e.preventDefault();
+        if (currentSelection) {
+            handleCopy();
+        } else {
+            handlePaste();
+        }
+    };
 
     return (
         <div className="terminal-container"
+            onKeyDown={handleKeyDown}
             onContextMenu={handleContextMenu}
+            tabIndex={0}
             style={{
             width: '100%',
             height: '100%',
@@ -411,7 +304,8 @@ export const TerminalComponent: React.FC<Props> = ({
             paddingBottom: '20px',
             boxSizing: 'border-box',
             backgroundColor: 'var(--bg-color)',
-            overflow: 'hidden'
+            overflow: 'hidden',
+            outline: 'none'
         }}>
             {isWaiting && (
                 <div className={`connection-overlay ${!isFailed ? 'loading' : 'failed'}`} style={{
@@ -529,13 +423,22 @@ export const TerminalComponent: React.FC<Props> = ({
                     </div>
                 </div>
             )}
-            <div ref={termRef} key={retryKey}
-                style={{
+            <div style={{
                     flex: 1,
                     minHeight: 0,
                     opacity: isReady ? 1 : 0,
                     transition: 'opacity 0.1s ease'
-                }} />
+                }}>
+                <CanvasRenderer
+                    core={terminalCore}
+                    theme={termTheme}
+                    fontFamily={terminalFontName}
+                    fontSize={terminalFontSize}
+                    visible={visible || false}
+                    onResize={handleResize}
+                    onSelectionChange={setCurrentSelection}
+                />
+            </div>
         </div>
     );
 };

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -52,9 +52,10 @@ export const TerminalComponent: React.FC<Props> = ({
 
     // Вычисляемые свойства (Derived State)
     const isWaiting = !showTerminal;
-    const isAuthFailed = status.startsWith('AUTH_FAILURE:');
-    const statusLower = status.toLowerCase();
-    const isClosed = status === 'Соединение закрыто';
+    const statusStr = status || '';
+    const isAuthFailed = statusStr.startsWith('AUTH_FAILURE:');
+    const statusLower = statusStr.toLowerCase();
+    const isClosed = statusStr === 'Соединение закрыто';
     const isFailed = statusLower.includes('ошибка') ||
                      statusLower.includes('error') ||
                      statusLower.includes('failed') ||
@@ -64,7 +65,7 @@ export const TerminalComponent: React.FC<Props> = ({
 
     const displayStatus = isAuthFailed
         ? 'Неверный логин или пароль'
-        : status;
+        : statusStr;
 
     // Refs for props to avoid effect re-runs
     const onOSInfoRef = useRef(onOSInfo);
@@ -101,10 +102,11 @@ export const TerminalComponent: React.FC<Props> = ({
             }
         };
 
-        const onStatus = (data: string) => {
+        const onStatus = (data: unknown) => {
             if (!isMountedRef.current) return;
-            setStatus(data);
-            if (data === 'Установлено соединение') {
+            const msg = (typeof data === 'string' ? data : '') || '';
+            setStatus(msg);
+            if (msg === 'Установлено соединение') {
                 wasConnectedRef.current = true;
                 setCountdown(null);
                 if (!config.osPrettyName) {
@@ -113,14 +115,15 @@ export const TerminalComponent: React.FC<Props> = ({
             }
         };
 
-        const onError = (data: string) => {
+        const onError = (data: unknown) => {
             if (isMountedRef.current) {
-                if (data.startsWith('AUTH_FAILURE:')) {
+                const msg = (typeof data === 'string' ? data : '') || 'Unknown error';
+                if (msg.startsWith('AUTH_FAILURE:')) {
                     wasConnectedRef.current = false;
                 }
-                const cleanError = data.startsWith('AUTH_FAILURE:') ? data.replace('AUTH_FAILURE:', '').trim() : data;
+                const cleanError = (typeof msg === 'string' && msg.startsWith('AUTH_FAILURE:')) ? msg.replace('AUTH_FAILURE:', '').trim() : msg;
                 terminalCore.write(`\r\n\x1b[31mОшибка: ${cleanError}\x1b[0m\r\n`);
-                setStatus(data);
+                setStatus(msg);
             }
         };
 

--- a/src/components/terminal/CanvasRenderer.tsx
+++ b/src/components/terminal/CanvasRenderer.tsx
@@ -1,0 +1,215 @@
+import React, { useRef, useEffect, useCallback, useState } from 'react';
+import { TerminalCore, TerminalTheme, Cell } from './terminal/TerminalCore';
+
+interface Props {
+    core: TerminalCore;
+    theme: TerminalTheme;
+    fontFamily: string;
+    fontSize: number;
+    visible: boolean;
+    onResize?: (cols: number, rows: number) => void;
+    onSelectionChange?: (selection: { startX: number, startY: number, endX: number, endY: number } | null) => void;
+}
+
+export const CanvasRenderer: React.FC<Props> = ({
+    core,
+    theme,
+    fontFamily,
+    fontSize,
+    visible,
+    onResize,
+    onSelectionChange
+}) => {
+    const containerRef = useRef<HTMLDivElement>(null);
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+    const charSizeRef = useRef({ width: 0, height: 0 });
+    const lastVersionRef = useRef(-1);
+
+    const [selection, setSelection] = useState<{ startX: number, startY: number, endX: number, endY: number } | null>(null);
+    const isSelectingRef = useRef(false);
+
+    const measureChar = useCallback(() => {
+        const canvas = document.createElement('canvas');
+        const ctx = canvas.getContext('2d');
+        if (!ctx) return { width: 0, height: 0 };
+        ctx.font = `${fontSize}px ${fontFamily}`;
+        const metrics = ctx.measureText('M');
+        return { width: metrics.width, height: fontSize };
+    }, [fontSize, fontFamily]);
+
+    const draw = useCallback(() => {
+        const canvas = canvasRef.current;
+        const ctx = canvas?.getContext('2d', { alpha: false });
+        if (!ctx || !canvas || !visible) return;
+
+        if (core.version === lastVersionRef.current && !isSelectingRef.current) return;
+        lastVersionRef.current = core.version;
+
+        const { width: charWidth, height: charHeight } = charSizeRef.current;
+        if (charWidth === 0 || charHeight === 0) return;
+
+        ctx.fillStyle = theme.background;
+        ctx.fillRect(0, 0, canvas.width, canvas.height);
+        ctx.textBaseline = 'top';
+
+        const { buffer, scrollback, scrollOffset, rows, cols } = core;
+
+        for (let y = 0; y < rows; y++) {
+            let displayRow: Cell[] = [];
+            const totalLines = scrollback.length + buffer.length;
+            const startLine = Math.max(0, totalLines - rows - scrollOffset);
+
+            if (startLine + y < scrollback.length) {
+                displayRow = scrollback[startLine + y];
+            } else {
+                displayRow = buffer[startLine + y - scrollback.length];
+            }
+
+            if (!displayRow) continue;
+
+            for (let x = 0; x < cols; x++) {
+                const cell = displayRow[x];
+                if (!cell || cell.width === 0) continue;
+
+                const posX = x * charWidth;
+                const posY = y * charHeight;
+
+                let isSelected = false;
+                if (selection) {
+                    const currentLine = startLine + y;
+                    const startLineIdx = Math.min(selection.startY, selection.endY);
+                    const endLineIdx = Math.max(selection.startY, selection.endY);
+
+                    if (currentLine > startLineIdx && currentLine < endLineIdx) {
+                        isSelected = true;
+                    } else if (currentLine === startLineIdx && currentLine === endLineIdx) {
+                        const minX = Math.min(selection.startX, selection.endX);
+                        const maxX = Math.max(selection.startX, selection.endX);
+                        isSelected = x >= minX && x <= maxX;
+                    } else if (currentLine === startLineIdx) {
+                        const startX = selection.startY < selection.endY ? selection.startX : selection.endX;
+                        isSelected = x >= startX;
+                    } else if (currentLine === endLineIdx) {
+                        const endX = selection.startY < selection.endY ? selection.endX : selection.startX;
+                        isSelected = x <= endX;
+                    }
+                }
+
+                if (isSelected) {
+                    ctx.fillStyle = theme.selectionBackground;
+                    ctx.fillRect(posX, posY, charWidth * cell.width, charHeight);
+                } else if (cell.attrs.bg !== 'transparent') {
+                    ctx.fillStyle = cell.attrs.bg as string;
+                    ctx.fillRect(posX, posY, charWidth * cell.width, charHeight);
+                }
+
+                if (cell.char !== ' ' && cell.char !== '') {
+                    ctx.fillStyle = isSelected ? theme.foreground : (cell.attrs.fg as string);
+                    ctx.font = `${cell.attrs.bold ? 'bold ' : ''}${fontSize}px ${fontFamily}`;
+                    ctx.fillText(cell.char, posX, posY);
+
+                    if (cell.attrs.underline) {
+                        ctx.strokeStyle = ctx.fillStyle;
+                        ctx.lineWidth = 1;
+                        ctx.beginPath();
+                        ctx.moveTo(posX, posY + charHeight - 1);
+                        ctx.lineTo(posX + charWidth * cell.width, posY + charHeight - 1);
+                        ctx.stroke();
+                    }
+                }
+            }
+        }
+
+        if (core.getShowCursor() && scrollOffset === 0) {
+            ctx.fillStyle = theme.cursor;
+            ctx.globalAlpha = 0.5;
+            ctx.fillRect(core.cursorX * charWidth, core.cursorY * charHeight, charWidth, charHeight);
+            ctx.globalAlpha = 1.0;
+        }
+    }, [core, theme, fontSize, fontFamily, visible, selection]);
+
+    useEffect(() => {
+        const size = measureChar();
+        charSizeRef.current = size;
+
+        const handleResize = () => {
+            if (!containerRef.current || !canvasRef.current) return;
+            const rect = containerRef.current.getBoundingClientRect();
+            const cols = Math.floor(rect.width / size.width);
+            const rows = Math.floor(rect.height / size.height);
+            canvasRef.current.width = rect.width;
+            canvasRef.current.height = rect.height;
+            if (cols > 0 && rows > 0 && (cols !== core.cols || rows !== core.rows)) {
+                core.resize(cols, rows);
+                if (onResize) onResize(cols, rows);
+            }
+            lastVersionRef.current = -1;
+            draw();
+        };
+
+        const observer = new ResizeObserver(handleResize);
+        if (containerRef.current) observer.observe(containerRef.current);
+        handleResize();
+        return () => observer.disconnect();
+    }, [core, measureChar, onResize, draw]);
+
+    useEffect(() => {
+        let frameId: number;
+        const renderLoop = () => {
+            draw();
+            frameId = requestAnimationFrame(renderLoop);
+        };
+        frameId = requestAnimationFrame(renderLoop);
+        return () => cancelAnimationFrame(frameId);
+    }, [draw]);
+
+    const getMousePos = (e: React.MouseEvent) => {
+        const rect = canvasRef.current?.getBoundingClientRect();
+        if (!rect) return { x: 0, y: 0 };
+        const x = Math.floor((e.clientX - rect.left) / charSizeRef.current.width);
+        const y = Math.floor((e.clientY - rect.top) / charSizeRef.current.height);
+        const totalLines = core.scrollback.length + core.buffer.length;
+        const currentLine = Math.max(0, totalLines - core.rows - core.scrollOffset) + y;
+        return { x, y: currentLine };
+    };
+
+    const handleMouseDown = (e: React.MouseEvent) => {
+        if (e.button !== 0) return;
+        const pos = getMousePos(e);
+        const sel = { startX: pos.x, startY: pos.y, endX: pos.x, endY: pos.y };
+        setSelection(sel);
+        if (onSelectionChange) onSelectionChange(sel);
+        isSelectingRef.current = true;
+    };
+
+    const handleMouseMove = (e: React.MouseEvent) => {
+        if (!isSelectingRef.current) return;
+        const pos = getMousePos(e);
+        setSelection(prev => {
+            const next = prev ? { ...prev, endX: pos.x, endY: pos.y } : null;
+            if (onSelectionChange) onSelectionChange(next);
+            return next;
+        });
+    };
+
+    const handleMouseUp = () => {
+        isSelectingRef.current = false;
+        // Selection stays until next click or manual clear
+    };
+
+    const handleWheel = useCallback((e: React.WheelEvent) => {
+        const delta = Math.round(e.deltaY / 20);
+        if (delta !== 0) core.scroll(delta);
+    }, [core]);
+
+    return (
+        <div ref={containerRef}
+             onWheel={handleWheel}
+             onMouseDown={handleMouseDown}
+             onMouseMove={handleMouseMove}
+             onMouseUp={handleMouseUp}
+             style={{ width: '100%', height: '100%', overflow: 'hidden' }}>
+            <canvas ref={canvasRef} style={{ display: 'block' }} />
+        </div>
+    );
+};

--- a/src/components/terminal/CanvasRenderer.tsx
+++ b/src/components/terminal/CanvasRenderer.tsx
@@ -32,10 +32,11 @@ export const CanvasRenderer: React.FC<Props> = ({
     const measureChar = useCallback(() => {
         const canvas = document.createElement('canvas');
         const ctx = canvas.getContext('2d');
-        if (!ctx) return { width: 0, height: 0 };
+        if (!ctx) return { width: 8, height: fontSize || 14 };
         ctx.font = `${fontSize}px ${fontFamily}`;
         const metrics = ctx.measureText('M');
-        return { width: metrics.width, height: fontSize };
+        const width = metrics.width || (fontSize * 0.6);
+        return { width, height: fontSize || 14 };
     }, [fontSize, fontFamily]);
 
     const draw = useCallback(() => {
@@ -130,8 +131,11 @@ export const CanvasRenderer: React.FC<Props> = ({
     }, [core, theme, fontSize, fontFamily, visible, selection]);
 
     useEffect(() => {
-        const size = measureChar();
-        charSizeRef.current = size;
+        const updateSizeAndRedraw = () => {
+            const size = measureChar();
+            charSizeRef.current = size;
+            handleResize();
+        };
 
         const handleResize = () => {
             if (!containerRef.current || !canvasRef.current) return;
@@ -150,7 +154,12 @@ export const CanvasRenderer: React.FC<Props> = ({
 
         const observer = new ResizeObserver(handleResize);
         if (containerRef.current) observer.observe(containerRef.current);
-        handleResize();
+
+        // Force update when fonts are ready
+        const fonts = (document as unknown as { fonts?: { ready: Promise<void> } }).fonts;
+        fonts?.ready.then(updateSizeAndRedraw);
+
+        updateSizeAndRedraw();
         return () => observer.disconnect();
     }, [core, measureChar, onResize, draw]);
 

--- a/src/components/terminal/CanvasRenderer.tsx
+++ b/src/components/terminal/CanvasRenderer.tsx
@@ -130,38 +130,39 @@ export const CanvasRenderer: React.FC<Props> = ({
         }
     }, [core, theme, fontSize, fontFamily, visible, selection]);
 
+    const handleResize = useCallback(() => {
+        if (!containerRef.current || !canvasRef.current) return;
+        const size = charSizeRef.current;
+        if (size.width === 0 || size.height === 0) return;
+
+        const rect = containerRef.current.getBoundingClientRect();
+        const cols = Math.floor(rect.width / size.width);
+        const rows = Math.floor(rect.height / size.height);
+        canvasRef.current.width = rect.width;
+        canvasRef.current.height = rect.height;
+        if (cols > 0 && rows > 0 && (cols !== core.cols || rows !== core.rows)) {
+            core.resize(cols, rows);
+            if (onResize) onResize(cols, rows);
+        }
+        lastVersionRef.current = -1;
+        draw();
+    }, [core, onResize, draw]);
+
     useEffect(() => {
         const updateSizeAndRedraw = () => {
-            const size = measureChar();
-            charSizeRef.current = size;
+            charSizeRef.current = measureChar();
             handleResize();
-        };
-
-        const handleResize = () => {
-            if (!containerRef.current || !canvasRef.current) return;
-            const rect = containerRef.current.getBoundingClientRect();
-            const cols = Math.floor(rect.width / size.width);
-            const rows = Math.floor(rect.height / size.height);
-            canvasRef.current.width = rect.width;
-            canvasRef.current.height = rect.height;
-            if (cols > 0 && rows > 0 && (cols !== core.cols || rows !== core.rows)) {
-                core.resize(cols, rows);
-                if (onResize) onResize(cols, rows);
-            }
-            lastVersionRef.current = -1;
-            draw();
         };
 
         const observer = new ResizeObserver(handleResize);
         if (containerRef.current) observer.observe(containerRef.current);
 
-        // Force update when fonts are ready
         const fonts = (document as unknown as { fonts?: { ready: Promise<void> } }).fonts;
         fonts?.ready.then(updateSizeAndRedraw);
 
         updateSizeAndRedraw();
         return () => observer.disconnect();
-    }, [core, measureChar, onResize, draw]);
+    }, [handleResize, measureChar]);
 
     useEffect(() => {
         let frameId: number;

--- a/src/components/terminal/CanvasRenderer.tsx
+++ b/src/components/terminal/CanvasRenderer.tsx
@@ -1,5 +1,6 @@
 import React, { useRef, useEffect, useCallback, useState } from 'react';
-import { TerminalCore, TerminalTheme, Cell } from './terminal/TerminalCore';
+import { TerminalCore } from './TerminalCore';
+import type { TerminalTheme, Cell } from './TerminalCore';
 
 interface Props {
     core: TerminalCore;
@@ -194,7 +195,6 @@ export const CanvasRenderer: React.FC<Props> = ({
 
     const handleMouseUp = () => {
         isSelectingRef.current = false;
-        // Selection stays until next click or manual clear
     };
 
     const handleWheel = useCallback((e: React.WheelEvent) => {

--- a/src/components/terminal/TerminalCore.ts
+++ b/src/components/terminal/TerminalCore.ts
@@ -1,0 +1,419 @@
+export interface CellAttrs {
+    fg: string | number;
+    bg: string | number;
+    bold?: boolean;
+    italic?: boolean;
+    underline?: boolean;
+}
+
+export interface Cell {
+    char: string;
+    attrs: CellAttrs;
+    width: number;
+}
+
+export interface TerminalTheme {
+    background: string;
+    foreground: string;
+    cursor: string;
+    selectionBackground: string;
+    black: string;
+    red: string;
+    green: string;
+    yellow: string;
+    blue: string;
+    magenta: string;
+    cyan: string;
+    white: string;
+    brightBlack: string;
+    brightRed: string;
+    brightGreen: string;
+    brightYellow: string;
+    brightBlue: string;
+    brightMagenta: string;
+    brightCyan: string;
+    brightWhite: string;
+}
+
+export class TerminalCore {
+    public rows: number = 24;
+    public cols: number = 80;
+
+    // Main buffer and alternate buffer
+    private mainBuffer: Cell[][] = [];
+    private altBuffer: Cell[][] = [];
+    public buffer: Cell[][] = [];
+
+    public cursorX: number = 0;
+    public cursorY: number = 0;
+    private savedCursorMain = { x: 0, y: 0 };
+    private savedCursorAlt = { x: 0, y: 0 };
+
+    public scrollback: Cell[][] = [];
+    public maxScrollback: number = 5000;
+
+    private currentAttrs: CellAttrs;
+    private theme: TerminalTheme;
+    private decoder = new TextDecoder('utf-8', { ignoreBOM: true });
+    private isAltBuffer = false;
+    private showCursor = true;
+
+    // Version/Change tracking
+    public version = 0;
+
+    constructor(cols: number, rows: number, theme: TerminalTheme) {
+        this.cols = cols;
+        this.rows = rows;
+        this.theme = theme;
+        this.currentAttrs = { fg: theme.foreground, bg: 'transparent' };
+        this.mainBuffer = this.createEmptyBuffer();
+        this.altBuffer = this.createEmptyBuffer();
+        this.buffer = this.mainBuffer;
+    }
+
+    private createEmptyBuffer(): Cell[][] {
+        return Array.from({ length: this.rows }, () =>
+            Array.from({ length: this.cols }, () => ({ char: ' ', attrs: { ...this.currentAttrs }, width: 1 }))
+        );
+    }
+
+    public updateTheme(theme: TerminalTheme) {
+        this.theme = theme;
+        this.version++;
+    }
+
+    public write(data: Uint8Array | string) {
+        const text = typeof data === 'string' ? data : this.decoder.decode(data, { stream: true });
+        let i = 0;
+
+        while (i < text.length) {
+            const char = text[i];
+
+            if (char === '\x1b') { // ESC
+                if (text[i + 1] === '[') { // CSI
+                    let j = i + 2;
+                    let sequence = '';
+                    while (j < text.length && text[j] >= '\x30' && text[j] <= '\x3f') {
+                        sequence += text[j];
+                        j++;
+                    }
+                    if (j < text.length) {
+                        const command = text[j];
+                        this.handleCSI(sequence, command);
+                        i = j + 1;
+                        continue;
+                    }
+                } else if (text[i + 1] === '?') {
+                     // Private mode handles or other ESC sequences
+                }
+            }
+
+            if (char === '\n') {
+                this.newLine();
+            } else if (char === '\r') {
+                this.cursorX = 0;
+            } else if (char === '\b') {
+                this.cursorX = Math.max(0, this.cursorX - 1);
+            } else if (char === '\t') {
+                const spaces = 8 - (this.cursorX % 8);
+                for(let s = 0; s < spaces; s++) this.putChar(' ');
+            } else if (char.charCodeAt(0) >= 32) {
+                this.putChar(char);
+            }
+            i++;
+        }
+        this.version++;
+    }
+
+    private isWide(char: string): boolean {
+        const code = char.codePointAt(0);
+        if (!code) return false;
+        // Basic check for emojis and wide characters
+        return (
+            (code >= 0x1100 && (
+                code <= 0x115f || // Hangul Jamo
+                code === 0x2329 || code === 0x232a ||
+                (0x2e80 <= code && code <= 0xa4cf && code !== 0x303f) || // CJK ... Yi
+                (0xac00 <= code && code <= 0xd7a3) || // Hangul Syllables
+                (0xf900 <= code && code <= 0xfaff) || // CJK Compatibility Ideographs
+                (0xfe10 <= code && code <= 0xfe19) || // Vertical forms
+                (0xfe30 <= code && code <= 0xfe6f) || // CJK Compatibility Forms
+                (0xff00 <= code && code <= 0xff60) || // Fullwidth Forms
+                (0xffe0 <= code && code <= 0xffe6) ||
+                (0x20000 <= code && code <= 0x2fffd) ||
+                (0x30000 <= code && code <= 0x3fffd)
+            )) ||
+            (code >= 0x1F300 && code <= 0x1F9FF) // Emojis
+        );
+    }
+
+    private putChar(char: string) {
+        const width = this.isWide(char) ? 2 : 1;
+
+        if (this.cursorX + width > this.cols) {
+            this.newLine();
+        }
+
+        if (this.cursorY >= this.rows) {
+            this.cursorY = this.rows - 1;
+        }
+
+        this.buffer[this.cursorY][this.cursorX] = {
+            char,
+            attrs: { ...this.currentAttrs },
+            width
+        };
+
+        if (width === 2 && this.cursorX + 1 < this.cols) {
+            this.buffer[this.cursorY][this.cursorX + 1] = {
+                char: '',
+                attrs: { ...this.currentAttrs },
+                width: 0
+            };
+        }
+
+        this.cursorX += width;
+    }
+
+    private newLine() {
+        this.cursorX = 0;
+        this.cursorY++;
+        if (this.cursorY >= this.rows) {
+            if (!this.isAltBuffer) {
+                // Circular buffer logic alternative:
+                const shiftedRow = this.mainBuffer.shift();
+                if (shiftedRow) {
+                    this.scrollback.push(shiftedRow);
+                    if (this.scrollback.length > this.maxScrollback) {
+                        this.scrollback.shift();
+                    }
+                }
+                this.mainBuffer.push(this.createEmptyRow());
+            }
+            this.cursorY = this.rows - 1;
+        }
+    }
+
+    private createEmptyRow(): Cell[] {
+        return Array.from({ length: this.cols }, () => ({ char: ' ', attrs: { ...this.currentAttrs }, width: 1 }));
+    }
+
+    private handleCSI(params: string, command: string) {
+        const parts = params.replace('?', '').split(';').map(p => parseInt(p) || 0);
+        const isPrivate = params.startsWith('?');
+
+        switch (command) {
+            case 'm': // SGR
+                this.handleSGR(parts);
+                break;
+            case 'H': // Cursor Position
+            case 'f':
+                this.cursorY = Math.min(this.rows - 1, Math.max(0, (parts[0] || 1) - 1));
+                this.cursorX = Math.min(this.cols - 1, Math.max(0, (parts[1] || 1) - 1));
+                break;
+            case 'J': // Erase in Display
+                this.eraseInDisplay(parts[0] || 0);
+                break;
+            case 'K': // Erase in Line
+                this.eraseInLine(parts[0] || 0);
+                break;
+            case 'h': // DECSET
+                if (isPrivate) this.handlePrivateMode(parts[0], true);
+                break;
+            case 'l': // DECRST
+                if (isPrivate) this.handlePrivateMode(parts[0], false);
+                break;
+            case 'n': // Device Status Report
+                if (parts[0] === 6) this.reportCursorPosition();
+                break;
+        }
+    }
+
+    private reportCursorPosition() {
+        const report = `\x1b[${this.cursorY + 1};${this.cursorX + 1}R`;
+        if (this.onInputCallback) this.onInputCallback(report);
+    }
+
+    private onInputCallback: ((data: string) => void) | null = null;
+
+    public setInputCallback(cb: (data: string) => void) {
+        this.onInputCallback = cb;
+    }
+
+    private handlePrivateMode(mode: number, value: boolean) {
+        switch (mode) {
+            case 1049: // Alternate Buffer
+            case 47:
+            case 1047:
+                this.switchBuffer(value);
+                break;
+            case 25: // Cursor show/hide
+                this.showCursor = value;
+                break;
+        }
+    }
+
+    private switchBuffer(toAlt: boolean) {
+        if (this.isAltBuffer === toAlt) return;
+
+        if (toAlt) {
+            this.savedCursorMain = { x: this.cursorX, y: this.cursorY };
+            this.buffer = this.altBuffer;
+            this.cursorX = this.savedCursorAlt.x;
+            this.cursorY = this.savedCursorAlt.y;
+        } else {
+            this.savedCursorAlt = { x: this.cursorX, y: this.cursorY };
+            this.buffer = this.mainBuffer;
+            this.cursorX = this.savedCursorMain.x;
+            this.cursorY = this.savedCursorMain.y;
+        }
+        this.isAltBuffer = toAlt;
+    }
+
+    private handleSGR(parts: number[]) {
+        if (parts.length === 0 || (parts.length === 1 && parts[0] === 0)) {
+            this.currentAttrs = { fg: this.theme.foreground, bg: 'transparent' };
+            return;
+        }
+
+        for (let i = 0; i < parts.length; i++) {
+            const p = parts[i];
+            if (p === 0) {
+                this.currentAttrs = { fg: this.theme.foreground, bg: 'transparent', bold: false, italic: false, underline: false };
+            } else if (p === 1) {
+                this.currentAttrs.bold = true;
+            } else if (p === 3) {
+                this.currentAttrs.italic = true;
+            } else if (p === 4) {
+                this.currentAttrs.underline = true;
+            } else if (p === 22) {
+                this.currentAttrs.bold = false;
+            } else if (p >= 30 && p <= 37) {
+                this.currentAttrs.fg = this.getThemeColor(p - 30);
+            } else if (p === 39) {
+                this.currentAttrs.fg = this.theme.foreground;
+            } else if (p >= 40 && p <= 47) {
+                this.currentAttrs.bg = this.getThemeColor(p - 40);
+            } else if (p === 49) {
+                this.currentAttrs.bg = 'transparent';
+            } else if (p >= 90 && p <= 97) {
+                this.currentAttrs.fg = this.getThemeColor(p - 90, true);
+            } else if (p >= 100 && p <= 107) {
+                this.currentAttrs.bg = this.getThemeColor(p - 100, true);
+            } else if (p === 38 || p === 48) {
+                // 256 colors or TrueColor
+                if (parts[i+1] === 5) { // 256 colors
+                    const colorIndex = parts[i+2];
+                    if (p === 38) this.currentAttrs.fg = this.get256Color(colorIndex);
+                    else this.currentAttrs.bg = this.get256Color(colorIndex);
+                    i += 2;
+                } else if (parts[i+1] === 2) { // TrueColor
+                    const r = parts[i+2];
+                    const g = parts[i+3];
+                    const b = parts[i+4];
+                    const color = `rgb(${r},${g},${b})`;
+                    if (p === 38) this.currentAttrs.fg = color;
+                    else this.currentAttrs.bg = color;
+                    i += 4;
+                }
+            }
+        }
+    }
+
+    private getThemeColor(index: number, bright: boolean = false): string {
+        const colors = [
+            bright ? this.theme.brightBlack : this.theme.black,
+            bright ? this.theme.brightRed : this.theme.red,
+            bright ? this.theme.brightGreen : this.theme.green,
+            bright ? this.theme.brightYellow : this.theme.yellow,
+            bright ? this.theme.brightBlue : this.theme.blue,
+            bright ? this.theme.brightMagenta : this.theme.magenta,
+            bright ? this.theme.brightCyan : this.theme.cyan,
+            bright ? this.theme.brightWhite : this.theme.white,
+        ];
+        return colors[index] || this.theme.foreground;
+    }
+
+    private get256Color(index: number): string {
+        if (index < 8) return this.getThemeColor(index);
+        if (index < 16) return this.getThemeColor(index - 8, true);
+        if (index < 232) {
+            const r = Math.floor((index - 16) / 36) * 51;
+            const g = Math.floor(((index - 16) % 36) / 6) * 51;
+            const b = ((index - 16) % 6) * 51;
+            return `rgb(${r},${g},${b})`;
+        }
+        const gray = (index - 232) * 10 + 8;
+        return `rgb(${gray},${gray},${gray})`;
+    }
+
+    private eraseInDisplay(mode: number) {
+        if (mode === 0) { // Cursor to end
+            this.eraseInLine(0);
+            for (let y = this.cursorY + 1; y < this.rows; y++) {
+                this.buffer[y] = this.createEmptyRow();
+            }
+        } else if (mode === 1) { // Start to cursor
+            this.eraseInLine(1);
+            for (let y = 0; y < this.cursorY; y++) {
+                this.buffer[y] = this.createEmptyRow();
+            }
+        } else if (mode === 2 || mode === 3) { // Entire display
+            for (let y = 0; y < this.rows; y++) {
+                this.buffer[y] = this.createEmptyRow();
+            }
+            this.cursorX = 0;
+            this.cursorY = 0;
+        }
+    }
+
+    private eraseInLine(mode: number) {
+        if (mode === 0) { // Cursor to end
+            for (let x = this.cursorX; x < this.cols; x++) {
+                this.buffer[this.cursorY][x] = { char: ' ', attrs: { ...this.currentAttrs }, width: 1 };
+            }
+        } else if (mode === 1) { // Start to cursor
+            for (let x = 0; x <= Math.min(this.cursorX, this.cols - 1); x++) {
+                this.buffer[this.cursorY][x] = { char: ' ', attrs: { ...this.currentAttrs }, width: 1 };
+            }
+        } else if (mode === 2) { // Entire line
+            this.buffer[this.cursorY] = this.createEmptyRow();
+        }
+    }
+
+    public resize(cols: number, rows: number) {
+        this.cols = cols;
+        this.rows = rows;
+        this.mainBuffer = this.resizeBuffer(this.mainBuffer, cols, rows);
+        this.altBuffer = this.resizeBuffer(this.altBuffer, cols, rows);
+        this.buffer = this.isAltBuffer ? this.altBuffer : this.mainBuffer;
+        this.cursorX = Math.min(this.cursorX, cols - 1);
+        this.cursorY = Math.min(this.cursorY, rows - 1);
+        this.version++;
+    }
+
+    private resizeBuffer(oldBuffer: Cell[][], cols: number, rows: number): Cell[][] {
+        const newBuffer = Array.from({ length: rows }, () =>
+            Array.from({ length: cols }, () => ({ char: ' ', attrs: { ...this.currentAttrs }, width: 1 }))
+        );
+        for (let y = 0; y < Math.min(oldBuffer.length, rows); y++) {
+            for (let x = 0; x < Math.min(oldBuffer[y].length, cols); x++) {
+                newBuffer[y][x] = oldBuffer[y][x];
+            }
+        }
+        return newBuffer;
+    }
+
+    public clear() {
+        this.mainBuffer = this.createEmptyBuffer();
+        this.altBuffer = this.createEmptyBuffer();
+        this.buffer = this.mainBuffer;
+        this.cursorX = 0;
+        this.cursorY = 0;
+        this.scrollback = [];
+        this.isAltBuffer = false;
+        this.version++;
+    }
+
+    public getShowCursor() { return this.showCursor; }
+}

--- a/src/components/terminal/TerminalCore.ts
+++ b/src/components/terminal/TerminalCore.ts
@@ -35,11 +35,17 @@ export interface TerminalTheme {
     brightWhite: string;
 }
 
+enum ParserState {
+    Normal,
+    Esc,
+    Csi,
+    Osc
+}
+
 export class TerminalCore {
     public rows: number = 24;
     public cols: number = 80;
 
-    // Main buffer and alternate buffer
     private mainBuffer: Cell[][] = [];
     private altBuffer: Cell[][] = [];
     public buffer: Cell[][] = [];
@@ -51,6 +57,10 @@ export class TerminalCore {
 
     public scrollback: Cell[][] = [];
     public maxScrollback: number = 5000;
+    public scrollOffset: number = 0;
+
+    private scrollTop: number = 0;
+    private scrollBottom: number = 23;
 
     private currentAttrs: CellAttrs;
     private theme: TerminalTheme;
@@ -58,14 +68,19 @@ export class TerminalCore {
     private isAltBuffer = false;
     private showCursor = true;
 
-    // Version/Change tracking
+    private state: ParserState = ParserState.Normal;
+    private params: string = '';
+    private intermediate: string = '';
+
     public version = 0;
+    private onInputCallback: ((data: string) => void) | null = null;
 
     constructor(cols: number, rows: number, theme: TerminalTheme) {
         this.cols = cols;
         this.rows = rows;
         this.theme = theme;
         this.currentAttrs = { fg: theme.foreground, bg: 'transparent' };
+        this.scrollBottom = rows - 1;
         this.mainBuffer = this.createEmptyBuffer();
         this.altBuffer = this.createEmptyBuffer();
         this.buffer = this.mainBuffer;
@@ -82,45 +97,72 @@ export class TerminalCore {
         this.version++;
     }
 
+    public setInputCallback(cb: (data: string) => void) {
+        this.onInputCallback = cb;
+    }
+
     public write(data: Uint8Array | string) {
         const text = typeof data === 'string' ? data : this.decoder.decode(data, { stream: true });
-        let i = 0;
 
-        while (i < text.length) {
+        for (let i = 0; i < text.length; i++) {
             const char = text[i];
 
-            if (char === '\x1b') { // ESC
-                if (text[i + 1] === '[') { // CSI
-                    let j = i + 2;
-                    let sequence = '';
-                    while (j < text.length && text[j] >= '\x30' && text[j] <= '\x3f') {
-                        sequence += text[j];
-                        j++;
+            switch (this.state) {
+                case ParserState.Normal:
+                    if (char === '\x1b') {
+                        this.state = ParserState.Esc;
+                    } else if (char === '\n') {
+                        this.newLine();
+                    } else if (char === '\r') {
+                        this.cursorX = 0;
+                    } else if (char === '\b') {
+                        this.cursorX = Math.max(0, this.cursorX - 1);
+                    } else if (char === '\t') {
+                        const spaces = 8 - (this.cursorX % 8);
+                        for(let s = 0; s < spaces; s++) this.putChar(' ');
+                    } else if (char.charCodeAt(0) >= 32) {
+                        this.putChar(char);
                     }
-                    if (j < text.length) {
-                        const command = text[j];
-                        this.handleCSI(sequence, command);
-                        i = j + 1;
-                        continue;
-                    }
-                } else if (text[i + 1] === '?') {
-                     // Private mode handles or other ESC sequences
-                }
-            }
+                    break;
 
-            if (char === '\n') {
-                this.newLine();
-            } else if (char === '\r') {
-                this.cursorX = 0;
-            } else if (char === '\b') {
-                this.cursorX = Math.max(0, this.cursorX - 1);
-            } else if (char === '\t') {
-                const spaces = 8 - (this.cursorX % 8);
-                for(let s = 0; s < spaces; s++) this.putChar(' ');
-            } else if (char.charCodeAt(0) >= 32) {
-                this.putChar(char);
+                case ParserState.Esc:
+                    if (char === '[') {
+                        this.state = ParserState.Csi;
+                        this.params = '';
+                        this.intermediate = '';
+                    } else if (char === ']') {
+                        this.state = ParserState.Osc;
+                    } else if (char === '7') {
+                        if (this.isAltBuffer) this.savedCursorAlt = { x: this.cursorX, y: this.cursorY };
+                        else this.savedCursorMain = { x: this.cursorX, y: this.cursorY };
+                        this.state = ParserState.Normal;
+                    } else if (char === '8') {
+                        const saved = this.isAltBuffer ? this.savedCursorAlt : this.savedCursorMain;
+                        this.cursorX = saved.x;
+                        this.cursorY = saved.y;
+                        this.state = ParserState.Normal;
+                    } else {
+                        this.state = ParserState.Normal;
+                    }
+                    break;
+
+                case ParserState.Csi:
+                    if (char >= '0' && char <= '9' || char === ';' || char === '?' || char === ':') {
+                        this.params += char;
+                    } else if (char >= ' ' && char <= '/') {
+                        this.intermediate += char;
+                    } else {
+                        this.handleCSI(this.params, char);
+                        this.state = ParserState.Normal;
+                    }
+                    break;
+
+                case ParserState.Osc:
+                    if (char === '\x07' || (char === '\\' && text[i-1] === '\x1b')) {
+                        this.state = ParserState.Normal;
+                    }
+                    break;
             }
-            i++;
         }
         this.version++;
     }
@@ -128,35 +170,31 @@ export class TerminalCore {
     private isWide(char: string): boolean {
         const code = char.codePointAt(0);
         if (!code) return false;
-        // Basic check for emojis and wide characters
         return (
             (code >= 0x1100 && (
-                code <= 0x115f || // Hangul Jamo
+                code <= 0x115f ||
                 code === 0x2329 || code === 0x232a ||
-                (0x2e80 <= code && code <= 0xa4cf && code !== 0x303f) || // CJK ... Yi
-                (0xac00 <= code && code <= 0xd7a3) || // Hangul Syllables
-                (0xf900 <= code && code <= 0xfaff) || // CJK Compatibility Ideographs
-                (0xfe10 <= code && code <= 0xfe19) || // Vertical forms
-                (0xfe30 <= code && code <= 0xfe6f) || // CJK Compatibility Forms
-                (0xff00 <= code && code <= 0xff60) || // Fullwidth Forms
+                (0x2e80 <= code && code <= 0xa4cf && code !== 0x303f) ||
+                (0xac00 <= code && code <= 0xd7a3) ||
+                (0xf900 <= code && code <= 0xfaff) ||
+                (0xfe10 <= code && code <= 0xfe19) ||
+                (0xfe30 <= code && code <= 0xfe6f) ||
+                (0xff00 <= code && code <= 0xff60) ||
                 (0xffe0 <= code && code <= 0xffe6) ||
                 (0x20000 <= code && code <= 0x2fffd) ||
                 (0x30000 <= code && code <= 0x3fffd)
             )) ||
-            (code >= 0x1F300 && code <= 0x1F9FF) // Emojis
+            (code >= 0x1F300 && code <= 0x1F9FF)
         );
     }
 
     private putChar(char: string) {
         const width = this.isWide(char) ? 2 : 1;
-
         if (this.cursorX + width > this.cols) {
             this.newLine();
         }
 
-        if (this.cursorY >= this.rows) {
-            this.cursorY = this.rows - 1;
-        }
+        if (this.cursorY >= this.rows) this.cursorY = this.rows - 1;
 
         this.buffer[this.cursorY][this.cursorX] = {
             char,
@@ -171,26 +209,35 @@ export class TerminalCore {
                 width: 0
             };
         }
-
         this.cursorX += width;
+        this.scrollOffset = 0;
     }
 
     private newLine() {
         this.cursorX = 0;
-        this.cursorY++;
-        if (this.cursorY >= this.rows) {
-            if (!this.isAltBuffer) {
-                // Circular buffer logic alternative:
-                const shiftedRow = this.mainBuffer.shift();
+        if (this.cursorY === this.scrollBottom) {
+            this.scrollUp(1);
+        } else if (this.cursorY < this.rows - 1) {
+            this.cursorY++;
+        }
+    }
+
+    private scrollUp(lines: number) {
+        const regionHeight = this.scrollBottom - this.scrollTop + 1;
+        lines = Math.min(lines, regionHeight);
+
+        for (let i = 0; i < lines; i++) {
+            if (!this.isAltBuffer && this.scrollTop === 0 && this.scrollBottom === this.rows - 1) {
+                const shiftedRow = this.buffer.shift();
                 if (shiftedRow) {
                     this.scrollback.push(shiftedRow);
-                    if (this.scrollback.length > this.maxScrollback) {
-                        this.scrollback.shift();
-                    }
+                    if (this.scrollback.length > this.maxScrollback) this.scrollback.shift();
                 }
-                this.mainBuffer.push(this.createEmptyRow());
+                this.buffer.push(this.createEmptyRow());
+            } else {
+                this.buffer.splice(this.scrollTop, 1);
+                this.buffer.splice(this.scrollBottom, 0, this.createEmptyRow());
             }
-            this.cursorY = this.rows - 1;
         }
     }
 
@@ -203,28 +250,26 @@ export class TerminalCore {
         const isPrivate = params.startsWith('?');
 
         switch (command) {
-            case 'm': // SGR
-                this.handleSGR(parts);
-                break;
-            case 'H': // Cursor Position
+            case 'm': this.handleSGR(parts); break;
+            case 'H':
             case 'f':
                 this.cursorY = Math.min(this.rows - 1, Math.max(0, (parts[0] || 1) - 1));
                 this.cursorX = Math.min(this.cols - 1, Math.max(0, (parts[1] || 1) - 1));
                 break;
-            case 'J': // Erase in Display
-                this.eraseInDisplay(parts[0] || 0);
-                break;
-            case 'K': // Erase in Line
-                this.eraseInLine(parts[0] || 0);
-                break;
-            case 'h': // DECSET
-                if (isPrivate) this.handlePrivateMode(parts[0], true);
-                break;
-            case 'l': // DECRST
-                if (isPrivate) this.handlePrivateMode(parts[0], false);
-                break;
-            case 'n': // Device Status Report
-                if (parts[0] === 6) this.reportCursorPosition();
+            case 'A': this.cursorY = Math.max(0, this.cursorY - (parts[0] || 1)); break;
+            case 'B': this.cursorY = Math.min(this.rows - 1, this.cursorY + (parts[0] || 1)); break;
+            case 'C': this.cursorX = Math.min(this.cols - 1, this.cursorX + (parts[0] || 1)); break;
+            case 'D': this.cursorX = Math.max(0, this.cursorX - (parts[0] || 1)); break;
+            case 'J': this.eraseInDisplay(parts[0] || 0); break;
+            case 'K': this.eraseInLine(parts[0] || 0); break;
+            case 'h': if (isPrivate) this.handlePrivateMode(parts[0], true); break;
+            case 'l': if (isPrivate) this.handlePrivateMode(parts[0], false); break;
+            case 'n': if (parts[0] === 6) this.reportCursorPosition(); break;
+            case 'r':
+                this.scrollTop = Math.max(0, (parts[0] || 1) - 1);
+                this.scrollBottom = Math.min(this.rows - 1, (parts[1] || this.rows) - 1);
+                this.cursorX = 0;
+                this.cursorY = 0;
                 break;
         }
     }
@@ -234,28 +279,19 @@ export class TerminalCore {
         if (this.onInputCallback) this.onInputCallback(report);
     }
 
-    private onInputCallback: ((data: string) => void) | null = null;
-
-    public setInputCallback(cb: (data: string) => void) {
-        this.onInputCallback = cb;
-    }
-
     private handlePrivateMode(mode: number, value: boolean) {
         switch (mode) {
-            case 1049: // Alternate Buffer
+            case 1049:
             case 47:
             case 1047:
                 this.switchBuffer(value);
                 break;
-            case 25: // Cursor show/hide
-                this.showCursor = value;
-                break;
+            case 25: this.showCursor = value; break;
         }
     }
 
     private switchBuffer(toAlt: boolean) {
         if (this.isAltBuffer === toAlt) return;
-
         if (toAlt) {
             this.savedCursorMain = { x: this.cursorX, y: this.cursorY };
             this.buffer = this.altBuffer;
@@ -272,7 +308,7 @@ export class TerminalCore {
 
     private handleSGR(parts: number[]) {
         if (parts.length === 0 || (parts.length === 1 && parts[0] === 0)) {
-            this.currentAttrs = { fg: this.theme.foreground, bg: 'transparent' };
+            this.currentAttrs = { fg: this.theme.foreground, bg: 'transparent', bold: false, italic: false, underline: false };
             return;
         }
 
@@ -280,37 +316,24 @@ export class TerminalCore {
             const p = parts[i];
             if (p === 0) {
                 this.currentAttrs = { fg: this.theme.foreground, bg: 'transparent', bold: false, italic: false, underline: false };
-            } else if (p === 1) {
-                this.currentAttrs.bold = true;
-            } else if (p === 3) {
-                this.currentAttrs.italic = true;
-            } else if (p === 4) {
-                this.currentAttrs.underline = true;
-            } else if (p === 22) {
-                this.currentAttrs.bold = false;
-            } else if (p >= 30 && p <= 37) {
-                this.currentAttrs.fg = this.getThemeColor(p - 30);
-            } else if (p === 39) {
-                this.currentAttrs.fg = this.theme.foreground;
-            } else if (p >= 40 && p <= 47) {
-                this.currentAttrs.bg = this.getThemeColor(p - 40);
-            } else if (p === 49) {
-                this.currentAttrs.bg = 'transparent';
-            } else if (p >= 90 && p <= 97) {
-                this.currentAttrs.fg = this.getThemeColor(p - 90, true);
-            } else if (p >= 100 && p <= 107) {
-                this.currentAttrs.bg = this.getThemeColor(p - 100, true);
-            } else if (p === 38 || p === 48) {
-                // 256 colors or TrueColor
-                if (parts[i+1] === 5) { // 256 colors
+            } else if (p === 1) this.currentAttrs.bold = true;
+            else if (p === 3) this.currentAttrs.italic = true;
+            else if (p === 4) this.currentAttrs.underline = true;
+            else if (p === 22) this.currentAttrs.bold = false;
+            else if (p >= 30 && p <= 37) this.currentAttrs.fg = this.getThemeColor(p - 30);
+            else if (p === 39) this.currentAttrs.fg = this.theme.foreground;
+            else if (p >= 40 && p <= 47) this.currentAttrs.bg = this.getThemeColor(p - 40);
+            else if (p === 49) this.currentAttrs.bg = 'transparent';
+            else if (p >= 90 && p <= 97) this.currentAttrs.fg = this.getThemeColor(p - 90, true);
+            else if (p >= 100 && p <= 107) this.currentAttrs.bg = this.getThemeColor(p - 100, true);
+            else if (p === 38 || p === 48) {
+                if (parts[i+1] === 5) {
                     const colorIndex = parts[i+2];
                     if (p === 38) this.currentAttrs.fg = this.get256Color(colorIndex);
                     else this.currentAttrs.bg = this.get256Color(colorIndex);
                     i += 2;
-                } else if (parts[i+1] === 2) { // TrueColor
-                    const r = parts[i+2];
-                    const g = parts[i+3];
-                    const b = parts[i+4];
+                } else if (parts[i+1] === 2) {
+                    const r = parts[i+2], g = parts[i+3], b = parts[i+4];
                     const color = `rgb(${r},${g},${b})`;
                     if (p === 38) this.currentAttrs.fg = color;
                     else this.currentAttrs.bg = color;
@@ -348,17 +371,17 @@ export class TerminalCore {
     }
 
     private eraseInDisplay(mode: number) {
-        if (mode === 0) { // Cursor to end
+        if (mode === 0) {
             this.eraseInLine(0);
             for (let y = this.cursorY + 1; y < this.rows; y++) {
                 this.buffer[y] = this.createEmptyRow();
             }
-        } else if (mode === 1) { // Start to cursor
+        } else if (mode === 1) {
             this.eraseInLine(1);
             for (let y = 0; y < this.cursorY; y++) {
                 this.buffer[y] = this.createEmptyRow();
             }
-        } else if (mode === 2 || mode === 3) { // Entire display
+        } else if (mode === 2 || mode === 3) {
             for (let y = 0; y < this.rows; y++) {
                 this.buffer[y] = this.createEmptyRow();
             }
@@ -368,15 +391,11 @@ export class TerminalCore {
     }
 
     private eraseInLine(mode: number) {
-        if (mode === 0) { // Cursor to end
-            for (let x = this.cursorX; x < this.cols; x++) {
-                this.buffer[this.cursorY][x] = { char: ' ', attrs: { ...this.currentAttrs }, width: 1 };
-            }
-        } else if (mode === 1) { // Start to cursor
-            for (let x = 0; x <= Math.min(this.cursorX, this.cols - 1); x++) {
-                this.buffer[this.cursorY][x] = { char: ' ', attrs: { ...this.currentAttrs }, width: 1 };
-            }
-        } else if (mode === 2) { // Entire line
+        if (mode === 0) {
+            for (let x = this.cursorX; x < this.cols; x++) this.buffer[this.cursorY][x] = { char: ' ', attrs: { ...this.currentAttrs }, width: 1 };
+        } else if (mode === 1) {
+            for (let x = 0; x <= Math.min(this.cursorX, this.cols - 1); x++) this.buffer[this.cursorY][x] = { char: ' ', attrs: { ...this.currentAttrs }, width: 1 };
+        } else if (mode === 2) {
             this.buffer[this.cursorY] = this.createEmptyRow();
         }
     }
@@ -389,6 +408,7 @@ export class TerminalCore {
         this.buffer = this.isAltBuffer ? this.altBuffer : this.mainBuffer;
         this.cursorX = Math.min(this.cursorX, cols - 1);
         this.cursorY = Math.min(this.cursorY, rows - 1);
+        this.scrollBottom = rows - 1;
         this.version++;
     }
 
@@ -411,9 +431,55 @@ export class TerminalCore {
         this.cursorX = 0;
         this.cursorY = 0;
         this.scrollback = [];
+        this.scrollOffset = 0;
         this.isAltBuffer = false;
+        this.scrollTop = 0;
+        this.scrollBottom = this.rows - 1;
         this.version++;
     }
 
     public getShowCursor() { return this.showCursor; }
+
+    public scroll(delta: number) {
+        if (this.isAltBuffer) return;
+        this.scrollOffset = Math.max(0, Math.min(this.scrollback.length, this.scrollOffset + delta));
+        this.version++;
+    }
+
+    public getSelectionText(selection: { startX: number, startY: number, endX: number, endY: number }): string {
+        let text = '';
+        const startLine = Math.min(selection.startY, selection.endY);
+        const endLine = Math.max(selection.startY, selection.endY);
+
+        for (let y = startLine; y <= endLine; y++) {
+            let row: Cell[];
+            if (y < this.scrollback.length) row = this.scrollback[y];
+            else row = this.buffer[y - this.scrollback.length];
+
+            if (!row) continue;
+
+            let lineText = '';
+            const isStartLine = y === startLine;
+            const isEndLine = y === endLine;
+
+            let startX = 0;
+            let endX = this.cols - 1;
+
+            if (isStartLine && isEndLine) {
+                startX = Math.min(selection.startX, selection.endX);
+                endX = Math.max(selection.startX, selection.endX);
+            } else if (isStartLine) {
+                startX = selection.startY < selection.endY ? selection.startX : selection.endX;
+            } else if (isEndLine) {
+                endX = selection.startY < selection.endY ? selection.endX : selection.startX;
+            }
+
+            for (let x = startX; x <= endX; x++) {
+                const cell = row[x];
+                if (cell && cell.char && cell.width > 0) lineText += cell.char;
+            }
+            text += lineText + (y < endLine ? '\n' : '');
+        }
+        return text;
+    }
 }

--- a/src/components/terminal/TerminalCore.ts
+++ b/src/components/terminal/TerminalCore.ts
@@ -404,6 +404,7 @@ export class TerminalCore {
     }
 
     public resize(cols: number, rows: number) {
+        if (cols <= 0 || rows <= 0) return;
         this.cols = cols;
         this.rows = rows;
         this.mainBuffer = this.resizeBuffer(this.mainBuffer, cols, rows);
@@ -411,6 +412,7 @@ export class TerminalCore {
         this.buffer = this.isAltBuffer ? this.altBuffer : this.mainBuffer;
         this.cursorX = Math.min(this.cursorX, cols - 1);
         this.cursorY = Math.min(this.cursorY, rows - 1);
+        this.scrollTop = 0;
         this.scrollBottom = rows - 1;
         this.version++;
     }

--- a/src/components/terminal/TerminalCore.ts
+++ b/src/components/terminal/TerminalCore.ts
@@ -104,9 +104,8 @@ export class TerminalCore {
     public write(data: Uint8Array | string) {
         const text = typeof data === 'string' ? data : this.decoder.decode(data, { stream: true });
 
-        for (let i = 0; i < text.length; i++) {
-            const char = text[i];
-
+        // Use for...of to correctly iterate over Unicode code points (handles surrogate pairs)
+        for (const char of text) {
             switch (this.state) {
                 case ParserState.Normal:
                     if (char === '\x1b') {
@@ -158,8 +157,12 @@ export class TerminalCore {
                     break;
 
                 case ParserState.Osc:
-                    if (char === '\x07' || (char === '\\' && text[i-1] === '\x1b')) {
+                    if (char === '\x07') {
                         this.state = ParserState.Normal;
+                    } else if (char === '\\' && this.params.endsWith('\x1b')) {
+                        this.state = ParserState.Normal;
+                    } else {
+                        this.params += char; // reuse params for OSC content
                     }
                     break;
             }

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,4 +1,4 @@
-export const getXtermTheme = (theme: string) => {
+export const getTerminalTheme = (theme: string) => {
     switch (theme) {
         case 'Dark':
             return {


### PR DESCRIPTION
Библиотека xterm.js была полностью заменена на кастомную реализацию терминала. 

Основные изменения:
1. **Ядро (TerminalCore)**: 
   - Использует конечный автомат для парсинга ANSI-последовательностей, что гарантирует стабильность при разрыве управляющих кодов между чанками данных.
   - Поддерживает Alternate Buffer (для TUI вроде vim/htop) и Scrolling Regions.
   - Реализовано определение ширины символов (wide chars/emojis).
   - Состояние терминала (буфер и история) сохраняется при смене темы оформления.

2. **Рендерер (CanvasRenderer)**:
   - Отрисовка через HTML5 Canvas с оптимизацией: кадр перерисовывается только при изменении версии буфера или выделения.
   - Нативная поддержка эмодзи (занимают 2 ячейки).
   - Поддержка стилей: жирный шрифт, подчеркивание.

3. **Интерфейс и Взаимодействие**:
   - Поддержка расширенного набора клавиш (F1-F12, Home, End, PgUp, PgDn).
   - Реализована вставка/копирование через Ctrl+Shift+C/V.
   - Правая кнопка мыши: копирует выделенный текст (если есть выделение) или вставляет из буфера обмена.

4. **Очистка**:
   - Удалены `@xterm/xterm` и все связанные аддоны из `package.json`.
   - Удалены устаревшие стили xterm из `App.css`.
   - Проект успешно проходит `npm run lint`.

---
*PR created automatically by Jules for task [11263851235111274492](https://jules.google.com/task/11263851235111274492) started by @megoRU*