### PR TITLE
Добавление поддержки ссылок в терминале и бамп версии до 1.6.2

### DIFF
--- a/electron/src/update-service.ts
+++ b/electron/src/update-service.ts
@@ -10,7 +10,8 @@ import { UpdateInfo, UpdateProgress } from './types.js'
 // Отключаем автоматическую загрузку, чтобы пользователь мог сам решить
 autoUpdater.autoDownload = false
 // Отключаем проверку подписи кода (необходимо для неподписанных приложений на macOS и Windows)
-autoUpdater.verifyUpdateCodeSignature = false
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+;(autoUpdater as any).verifyUpdateCodeSignature = false
 
 /**
  * Инициализирует слушатели автообновления.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "yetanothersshclient",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yetanothersshclient",
-      "version": "1.6.1",
+      "version": "1.6.2",
       "dependencies": {
         "@xterm/addon-clipboard": "^0.2.0",
         "@xterm/addon-fit": "^0.11.0",
+        "@xterm/addon-web-links": "^0.12.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
         "electron-updater": "^6.8.3",
@@ -2661,6 +2662,12 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@xterm/addon-fit/-/addon-fit-0.11.0.tgz",
       "integrity": "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g==",
+      "license": "MIT"
+    },
+    "node_modules/@xterm/addon-web-links": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@xterm/addon-web-links/-/addon-web-links-0.12.0.tgz",
+      "integrity": "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw==",
       "license": "MIT"
     },
     "node_modules/@xterm/addon-webgl": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yetanothersshclient",
   "private": true,
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "A modern multi-platform SSH client built with React and Electron",
   "repository": {
     "type": "git",
@@ -25,6 +25,7 @@
   "dependencies": {
     "@xterm/addon-clipboard": "^0.2.0",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "electron-updater": "^6.8.3",

--- a/src/components/SFTPBrowser.tsx
+++ b/src/components/SFTPBrowser.tsx
@@ -27,7 +27,7 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig,
     const [isProcessing, setIsProcessing] = useState(false);
     const [activeTransfers, setActiveTransfers] = useState<Transfer[]>([]);
     const pendingUpdatesRef = useRef<SftpProgress[]>([]);
-    const throttleTimerRef = useRef<NodeJS.Timeout | null>(null);
+    const throttleTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
     const [isDragging, setIsDragging] = useState(false);
     const dragCounter = useRef(0);
     const pendingDeletesRef = useRef<string[]>([]);
@@ -537,7 +537,7 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig,
         const droppedFilesWithPaths = await Promise.all(droppedFiles.map(async f => {
             const localPath = ipcRenderer.getPathForFile(f);
             if (!localPath) return null;
-            const stats = await ipcRenderer.invoke('fs-stat', localPath);
+            const stats = await ipcRenderer.invoke('fs-stat', localPath) as { size: number, isDir: boolean } | null;
             return {
                 name: f.name,
                 size: stats?.size || 0,
@@ -908,7 +908,8 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig,
                         onClose={() => setModal(null)} onConfirm={() => {
                 if (modal?.type === 'delete') handleDelete(); else if (modal?.type === 'rename') handleRename(); else if (modal?.type === 'mkdir') handleCreateDirectory(); else if (modal?.type === 'permissions') handlePermissions(); else if (modal?.type === 'error') setModal(null); else if (modal?.type === 'cancelUpload') setModal(null); else if (modal?.type === 'fileUpdate') {
                     const transferId = Math.random().toString(36).substr(2, 9);
-                    ipcRenderer.invoke('fs-stat', modal.localPath).then((stats: { size: number }) => {
+                    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                    ipcRenderer.invoke('fs-stat', modal.localPath).then((stats: any) => {
                         const newTransfer: Transfer = {
                             id: transferId,
                             filename: modal.filename || 'unknown',

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useRef, useState, useCallback } from 'react';
 import { Terminal } from '@xterm/xterm';
 import { FitAddon } from '@xterm/addon-fit';
 import { ClipboardAddon } from '@xterm/addon-clipboard';
+import { WebLinksAddon } from '@xterm/addon-web-links';
 import { WebglAddon } from '@xterm/addon-webgl';
 import { Terminal as IconTerminal, Plug } from 'lucide-react';
 import { getXtermTheme } from '../utils/theme';
@@ -139,8 +140,13 @@ export const TerminalComponent: React.FC<Props> = ({
 
         const fitAddon = new FitAddon();
         const clipboardAddon = new ClipboardAddon();
+        const webLinksAddon = new WebLinksAddon((_event, url) => {
+            ipcRenderer.send('open-external', url);
+        });
+
         term.loadAddon(fitAddon);
         term.loadAddon(clipboardAddon);
+        term.loadAddon(webLinksAddon);
         term.open(termRef.current);
 
         try {

--- a/src/components/layout/ContextMenu.tsx
+++ b/src/components/layout/ContextMenu.tsx
@@ -47,7 +47,7 @@ export const ContextMenu: React.FC<ContextMenuProps> = ({x, y, options, onClose}
         }
 
         setPos(prev => {
-            if (prev.left === left && prev.top === top && prev.ready === true) return prev;
+            if (prev.left === left && prev.top === top && prev.ready) return prev;
             return {left, top, ready: true};
         });
     }, [x, y]);

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,7 +101,7 @@ export interface Transfer {
 
 export type NotificationType = 'success' | 'error' | 'info';
 
-export const VERSION = '1.6.1';
+export const VERSION = '1.6.2';
 
 export interface SftpDownloadResult {
     remotePath: string;


### PR DESCRIPTION
В этом PR реализована поддержка кликабельных ссылок в терминале с использованием официального аддона `@xterm/addon-web-links`. При клике на ссылку в терминале, приложение отправляет IPC-сообщение в основной процесс, который открывает URL в браузере по умолчанию. Также произведено плановое обновление версии приложения до 1.6.2.

---
*PR created automatically by Jules for task [16915466246139176633](https://jules.google.com/task/16915466246139176633) started by @megoRU*