### PR TITLE
Add success sound notification for SFTP uploads

### DIFF
--- a/src/components/SFTPBrowser.tsx
+++ b/src/components/SFTPBrowser.tsx
@@ -6,7 +6,7 @@ import {SftpFileList} from './sftp/SftpFileList';
 import {SftpTransferPanel} from './sftp/SftpTransferPanel';
 import {SftpModals} from './sftp/SftpModals';
 import type {AppConfig, SftpFileEntry, SftpProgress, SSHConfig, Transfer} from '../types';
-import {normalizeRemotePath} from '../utils';
+import {normalizeRemotePath, playSuccessSound} from '../utils';
 import {useI18n} from '../utils/i18n';
 
 const {ipcRenderer} = window;
@@ -394,6 +394,7 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig,
                     transferId: t.id
                 }))
             });
+            playSuccessSound();
             loadDirectory(path);
         } catch (err: unknown) {
             const message = err instanceof Error ? err.message : String(err);
@@ -581,6 +582,7 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig,
                     transferId: t.id
                 }))
             });
+            playSuccessSound();
             loadDirectory(path);
         } catch (err: unknown) {
             const message = err instanceof Error ? err.message : String(err);
@@ -933,6 +935,7 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig,
                             remotePath: modal.remotePath,
                             transferId
                         }).then(() => {
+                            playSuccessSound();
                             setModal(null);
                             loadDirectory(path);
                         });

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -69,3 +69,8 @@ export const stripHtml = (html: string | undefined | null) => {
         .map(line => `• ${line}`)
         .join('\n');
 };
+
+export const playSuccessSound = () => {
+    const audio = new Audio('/sound/success.wav');
+    audio.play().catch(err => console.error('Failed to play success sound:', err));
+};


### PR DESCRIPTION
This PR adds an audio notification that plays when a file or folder is successfully uploaded via SFTP.

Changes:
1.  **Utility Addition**: A new `playSuccessSound` function was added to `src/utils/index.ts`. It uses the Web Audio API to play the `success.wav` file located in the `public/sound` directory. It includes a catch block to handle potential browser playback restrictions.
2.  **SFTP Integration**: The `SFTPBrowser.tsx` component was updated to trigger the success sound in three key scenarios:
    *   Manual file/folder uploads via the toolbar.
    *   File/folder uploads via drag-and-drop.
    *   Direct file uploads when a locally edited file is synced back to the server.

Verification:
- Linting passed (`npm run lint`).
- Manual code inspection confirmed sound triggers are placed in the correct success callbacks.
- Absence of automated tests confirmed.

---
*PR created automatically by Jules for task [4098989515909392009](https://jules.google.com/task/4098989515909392009) started by @megoRU*