### PR TITLE
Fix success sound and font loading in production build

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yetanothersshclient",
-  "version": "1.6.5",
+  "version": "1.6.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yetanothersshclient",
-      "version": "1.6.5",
+      "version": "1.6.6",
       "dependencies": {
         "@xterm/addon-clipboard": "^0.2.0",
         "@xterm/addon-fit": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yetanothersshclient",
   "private": true,
-  "version": "1.6.5",
+  "version": "1.6.6",
   "description": "A modern multi-platform SSH client built with React and Electron",
   "repository": {
     "type": "git",

--- a/src/App.css
+++ b/src/App.css
@@ -1,27 +1,27 @@
-@font-face { font-family: 'Droid Sans Mono'; src: url('/fonts/Droid Sans Mono.ttf') format('truetype'); font-weight: 400; font-style: normal; }
-@font-face { font-family: 'DejaVu Sans Mono'; src: url('/fonts/DejaVuSansMono.ttf') format('truetype'); font-weight: 400; font-style: normal; }
-@font-face { font-family: 'PT Mono'; src: url('/fonts/PTMono-Regular.ttf') format('truetype'); font-weight: 400; font-style: normal; }
-@font-face { font-family: 'Cascadia Code'; src: url('/fonts/Cascadia Code.ttf') format('truetype'); font-weight: 400; font-style: normal; }
+@font-face { font-family: 'Droid Sans Mono'; src: url('./fonts/Droid Sans Mono.ttf') format('truetype'); font-weight: 400; font-style: normal; }
+@font-face { font-family: 'DejaVu Sans Mono'; src: url('./fonts/DejaVuSansMono.ttf') format('truetype'); font-weight: 400; font-style: normal; }
+@font-face { font-family: 'PT Mono'; src: url('./fonts/PTMono-Regular.ttf') format('truetype'); font-weight: 400; font-style: normal; }
+@font-face { font-family: 'Cascadia Code'; src: url('./fonts/Cascadia Code.ttf') format('truetype'); font-weight: 400; font-style: normal; }
 
-@font-face { font-family: 'Fira Code'; src: url('/fonts/FiraCode-Regular.ttf') format('truetype'); font-weight: 400; font-style: normal; }
-@font-face { font-family: 'Fira Code'; src: url('/fonts/FiraCode-Medium.ttf') format('truetype'); font-weight: 500; font-style: normal; }
-@font-face { font-family: 'Fira Code'; src: url('/fonts/FiraCode-Bold.ttf') format('truetype'); font-weight: 700; font-style: normal; }
+@font-face { font-family: 'Fira Code'; src: url('./fonts/FiraCode-Regular.ttf') format('truetype'); font-weight: 400; font-style: normal; }
+@font-face { font-family: 'Fira Code'; src: url('./fonts/FiraCode-Medium.ttf') format('truetype'); font-weight: 500; font-style: normal; }
+@font-face { font-family: 'Fira Code'; src: url('./fonts/FiraCode-Bold.ttf') format('truetype'); font-weight: 700; font-style: normal; }
 
-@font-face { font-family: 'JetBrains Mono'; src: url('/fonts/JetBrains Mono.ttf') format('truetype'); font-weight: 400; font-style: normal; }
-@font-face { font-family: 'JetBrains Mono'; src: url('/fonts/JetBrainsMono-Medium.ttf') format('truetype'); font-weight: 500; font-style: normal; }
-@font-face { font-family: 'JetBrains Mono'; src: url('/fonts/JetBrainsMono-Bold.ttf') format('truetype'); font-weight: 700; font-style: normal; }
+@font-face { font-family: 'JetBrains Mono'; src: url('./fonts/JetBrains Mono.ttf') format('truetype'); font-weight: 400; font-style: normal; }
+@font-face { font-family: 'JetBrains Mono'; src: url('./fonts/JetBrainsMono-Medium.ttf') format('truetype'); font-weight: 500; font-style: normal; }
+@font-face { font-family: 'JetBrains Mono'; src: url('./fonts/JetBrainsMono-Bold.ttf') format('truetype'); font-weight: 700; font-style: normal; }
 
-@font-face { font-family: 'Source Code Pro'; src: url('/fonts/Source Code Pro.ttf') format('truetype'); font-weight: 400; font-style: normal; }
-@font-face { font-family: 'Source Code Pro'; src: url('/fonts/Source Code Pro Medium.ttf') format('truetype'); font-weight: 500; font-style: normal; }
+@font-face { font-family: 'Source Code Pro'; src: url('./fonts/Source Code Pro.ttf') format('truetype'); font-weight: 400; font-style: normal; }
+@font-face { font-family: 'Source Code Pro'; src: url('./fonts/Source Code Pro Medium.ttf') format('truetype'); font-weight: 500; font-style: normal; }
 
-@font-face { font-family: 'Fira Mono'; src: url('/fonts/Fira Mono.ttf') format('truetype'); font-weight: 400; font-style: normal; }
-@font-face { font-family: 'Fira Mono'; src: url('/fonts/Fira Mono Medium.ttf') format('truetype'); font-weight: 500; font-style: normal; }
+@font-face { font-family: 'Fira Mono'; src: url('./fonts/Fira Mono.ttf') format('truetype'); font-weight: 400; font-style: normal; }
+@font-face { font-family: 'Fira Mono'; src: url('./fonts/Fira Mono Medium.ttf') format('truetype'); font-weight: 500; font-style: normal; }
 
-@font-face { font-family: 'Ubuntu Mono'; src: url('/fonts/Ubuntu Mono.ttf') format('truetype'); font-weight: 400; font-style: normal; }
+@font-face { font-family: 'Ubuntu Mono'; src: url('./fonts/Ubuntu Mono.ttf') format('truetype'); font-weight: 400; font-style: normal; }
 
-@font-face { font-family: 'Inter'; src: url('/fonts/Inter_18pt-Regular.ttf') format('truetype'); font-weight: 400; font-style: normal; }
-@font-face { font-family: 'Inter'; src: url('/fonts/Inter_18pt-Medium.ttf') format('truetype'); font-weight: 500; font-style: normal; }
-@font-face { font-family: 'Inter'; src: url('/fonts/Inter_18pt-Bold.ttf') format('truetype'); font-weight: 700; font-style: normal; }
+@font-face { font-family: 'Inter'; src: url('./fonts/Inter_18pt-Regular.ttf') format('truetype'); font-weight: 400; font-style: normal; }
+@font-face { font-family: 'Inter'; src: url('./fonts/Inter_18pt-Medium.ttf') format('truetype'); font-weight: 500; font-style: normal; }
+@font-face { font-family: 'Inter'; src: url('./fonts/Inter_18pt-Bold.ttf') format('truetype'); font-weight: 700; font-style: normal; }
 
 *, *::before, *::after {
     box-sizing: border-box;

--- a/src/index.css
+++ b/src/index.css
@@ -1,20 +1,20 @@
 @font-face {
   font-family: 'JetBrains Mono';
-  src: url('/fonts/JetBrainsMono-Regular.ttf') format('truetype');
+  src: url('./fonts/JetBrainsMono-Regular.ttf') format('truetype');
   font-weight: 400;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'JetBrains Mono';
-  src: url('/fonts/JetBrainsMono-Medium.ttf') format('truetype');
+  src: url('./fonts/JetBrainsMono-Medium.ttf') format('truetype');
   font-weight: 500 600;
   font-style: normal;
 }
 
 @font-face {
   font-family: 'JetBrains Mono';
-  src: url('/fonts/JetBrainsMono-Bold.ttf') format('truetype');
+  src: url('./fonts/JetBrainsMono-Bold.ttf') format('truetype');
   font-weight: 700 800;
   font-style: normal;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -106,7 +106,7 @@ export interface Transfer {
 
 export type NotificationType = 'success' | 'error' | 'info';
 
-export const VERSION = '1.6.5';
+export const VERSION = '1.6.6';
 
 export interface SftpDownloadResult {
     remotePath: string;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -71,7 +71,7 @@ export const stripHtml = (html: string | undefined | null) => {
 };
 
 export const playSuccessSound = (volume: number = 0.5) => {
-    const audio = new Audio('/sound/success.wav');
+    const audio = new Audio('./sound/success.wav');
     audio.volume = Math.min(1, Math.max(0, volume));
     audio.play().catch(err => console.error('Failed to play success sound:', err));
 };


### PR DESCRIPTION
This PR fixes the issue where the success notification sound was missing in the production build of the application. 

The root cause was the use of absolute paths for assets in the renderer process. In the production Electron environment (especially with the `base: './'` configuration in Vite), absolute paths starting with `/` may resolve to the root of the file system instead of the application directory.

Specifically:
- Updated `playSuccessSound` in `src/utils/index.ts` to use `./sound/success.wav`.
- Updated all `@font-face` URL paths in `src/App.css` and `src/index.css` to use `./fonts/` instead of `/fonts/`.

These changes ensure that sounds and fonts are correctly loaded regardless of the application's installation path.

---
*PR created automatically by Jules for task [1664133245156506585](https://jules.google.com/task/1664133245156506585) started by @megoRU*