### PR TITLE
Harden renderer security, sanitize external links, and strengthen vault/port-forwarding handling

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, dialog, powerSaveBlocker, nativeTheme, screen } from 'electron'
+import { app, BrowserWindow, dialog, powerSaveBlocker, nativeTheme, screen, shell } from 'electron'
 import * as path from 'node:path'
 import * as fs from 'node:fs'
 import { fileURLToPath } from 'node:url'
@@ -199,6 +199,7 @@ function createWindow(): void {
             preload: preloadPath,
             contextIsolation: true,
             nodeIntegration: false,
+            sandbox: true,
             backgroundThrottling: false
         },
         title: 'YetAnotherSSHClient'
@@ -300,6 +301,22 @@ function createWindow(): void {
             }
         }
     })
+
+    // Блокируем навигацию и открытие новых окон внутри renderer для снижения риска эскалации через XSS
+    mainWindow.webContents.on('will-navigate', (event) => {
+        event.preventDefault()
+    })
+    mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+        try {
+            const parsed = new URL(url)
+            if (parsed.protocol === 'https:' || parsed.protocol === 'http:') {
+                void shell.openExternal(parsed.toString())
+            }
+        } catch {
+            // ignore malformed url
+        }
+        return { action: 'deny' }
+    })
 }
 
 /**
@@ -321,7 +338,8 @@ function createPortForwardingWindow(config: SSHConfig): void {
         webPreferences: {
             preload: preloadPath,
             contextIsolation: true,
-            nodeIntegration: false
+            nodeIntegration: false,
+            sandbox: true
         },
         title: 'Port Forwarding'
     })
@@ -329,11 +347,11 @@ function createPortForwardingWindow(config: SSHConfig): void {
     const params = new URLSearchParams({
         theme: appConfig.theme,
         view: 'port-forwarding',
+        id: config.id || '',
         host: config.host,
         user: config.user,
         port: config.port.toString(),
         name: config.name || '',
-        password: config.password || '',
         authType: config.authType || 'password',
         privateKeyPath: config.privateKeyPath || ''
     }).toString()
@@ -349,11 +367,11 @@ function createPortForwardingWindow(config: SSHConfig): void {
             query: {
                 theme: appConfig.theme,
                 view: 'port-forwarding',
+                id: config.id || '',
                 host: config.host,
                 user: config.user,
                 port: config.port.toString(),
                 name: config.name || '',
-                password: config.password || '',
                 authType: config.authType || 'password',
                 privateKeyPath: config.privateKeyPath || ''
             }

--- a/electron/src/ipc-handlers.ts
+++ b/electron/src/ipc-handlers.ts
@@ -1276,8 +1276,13 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
     // Внешние ссылки
     ipcMain.on('open-external', (_, url: string) => {
         if (typeof url !== 'string' || url.length > 2048) return
-        if (url.trim().startsWith('http')) {
-            shell.openExternal(url).catch(err => console.error('Failed to open external URL:', err))
+        try {
+            const parsedUrl = new URL(url.trim())
+            if (parsedUrl.protocol === 'https:' || parsedUrl.protocol === 'http:') {
+                shell.openExternal(parsedUrl.toString()).catch(err => console.error('Failed to open external URL:', err))
+            }
+        } catch {
+            // ignore malformed URLs
         }
     })
 
@@ -1440,7 +1445,21 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
 
         try {
             const config = loadConfig()
-            vault.unlock(recoveryKey, config.encryption!.salt)
+            if (!config.encryption?.salt) return false
+            const keyBuffer = Buffer.from(recoveryKey, 'base64')
+            if (keyBuffer.length !== 32) return false
+
+            vault.unlock(recoveryKey, config.encryption.salt)
+
+            const firstEncrypted = Object.values(config.encryptedPasswords || {})[0]
+            if (firstEncrypted) {
+                try {
+                    vault.decrypt(firstEncrypted)
+                } catch {
+                    vault.lock()
+                    return false
+                }
+            }
 
             if (vault.isUnlocked()) {
                 // Cache for auto-unlock

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -324,11 +324,11 @@ function App() {
 
     if (view === 'port-forwarding') {
         const sshConfig: SSHConfig = {
+            id: urlParams.get('id') || undefined,
             host: urlParams.get('host') || '',
             user: urlParams.get('user') || '',
             port: parseInt(urlParams.get('port') || '22'),
             name: urlParams.get('name') || '',
-            password: urlParams.get('password') || '',
             authType: (urlParams.get('authType') as 'password' | 'key') || 'password',
             privateKeyPath: urlParams.get('privateKeyPath') || ''
         };


### PR DESCRIPTION
### Motivation
- Reduce XSS/renderer attack surface by sandboxing renderers and preventing in-app navigation or unexpected window creation.
- Avoid leaking sensitive data (passwords) via window query parameters and ensure port-forwarding windows receive a stable identifier.
- Improve robustness of external link handling and vault unlocking by validating inputs and failing safely.

### Description
- Added `shell` import and set `webPreferences.sandbox = true` for the main and port-forwarding `BrowserWindow` instances to harden renderer isolation.
- Prevented in-renderer navigation with `will-navigate.preventDefault()` and blocked window.open while opening http/https links via `shell.openExternal` using `setWindowOpenHandler`.
- Removed sending plain `password` in port-forwarding query parameters and added an `id` parameter to identify the forwarded SSH config instead of embedding secrets.
- Strengthened `open-external` IPC to validate URLs using the `URL` constructor and only allow `http`/`https` schemes, ignoring malformed inputs.
- Tightened `vault-unlock` handling by checking for an encryption salt, validating the provided base64 recovery key length (32 bytes), attempting to decrypt a sample encrypted entry to verify correctness, and locking/returning false on failure.

### Testing
- Ran `npm run build` (TypeScript compile) and the project compiled successfully.
- Ran the test suite with `npm test` and unit tests completed without failures.
- Ran `npm run lint` and static checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff1cfd6e98832abf49e5c13636fd78)