### PR TITLE
Исправить типизацию уведомлений и обновлений конфигурации

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,7 +23,7 @@ import { useI18n } from './utils/i18n';
 import { useTabs } from './hooks/useTabs';
 import { useSystemFonts } from './hooks/useSystemFonts';
 import { useUpdateChecker } from './hooks/useUpdateChecker';
-import type { SSHConfig, NotificationType } from './types';
+import type { AppConfig, NotificationAction, SSHConfig, NotificationType } from './types';
 import { generateId } from './utils';
 
 import './styles/light.css';
@@ -85,7 +85,7 @@ function App() {
     const [showReloadModal, setShowReloadModal] = useState(false);
     const [vaultStatus, setVaultStatus] = useState<{ isUnlocked: boolean, isInitialized: boolean }>({ isUnlocked: true, isInitialized: false });
     const [recoveryKeyToShow, setRecoveryKeyModal] = useState<string | null>(null);
-    const [notification, setNotification] = useState<{ title: string, message: string, type?: NotificationType, action?: { label: string, onClick: () => void } } | null>(null);
+    const [notification, setNotification] = useState<{ title: string, message: string, type?: NotificationType, action?: NotificationAction } | null>(null);
     const [contextMenu, setContextMenu] = useState<{ x: number, y: number, options?: { label: string, icon: React.ReactNode, onClick: () => void, danger?: boolean }[], config?: SSHConfig } | null>(null);
 
     const isConnectingRef = useRef(false);
@@ -105,8 +105,7 @@ function App() {
             } else {
                 // If we can't get the key (e.g. safeStorage issue) but it's marked as unacknowledged,
                 // we should probably not block the user forever.
-                // eslint-disable-next-line @typescript-eslint/no-explicit-any
-                setConfig((prev: any) => prev ? { ...prev, hasAcknowledgedRecoveryKey: true } : prev);
+                setConfig((prev: AppConfig | null) => prev ? { ...prev, hasAcknowledgedRecoveryKey: true } : prev);
             }
         }
     }, [config, recoveryKeyToShow, setConfig]);
@@ -295,16 +294,14 @@ function App() {
 
     const handleOnboardingComplete = useCallback(async () => {
         // Initialize vault on first run
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const result = await ipcRenderer?.vaultInit?.() as { recoveryKey: string, config: any } | null;
+        const result = await ipcRenderer?.vaultInit?.() as { recoveryKey: string, config: AppConfig } | null;
         if (result) {
             setRecoveryKeyModal(result.recoveryKey);
             setVaultStatus({ isUnlocked: true, isInitialized: true });
             // Use the config returned from main process to avoid state desync
             setConfig({ ...result.config, isOnboardingCompleted: true });
         } else {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            setConfig((prev: any) => prev ? { ...prev, isOnboardingCompleted: true } : prev);
+            setConfig((prev: AppConfig | null) => prev ? { ...prev, isOnboardingCompleted: true } : prev);
         }
     }, [setConfig]);
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -314,7 +314,7 @@ function App() {
     };
 
     const handleVaultResetPasswords = async () => {
-        const result = await ipcRenderer?.vaultReset?.() as { recoveryKey: string, config: typeof config } | null;
+        const result = await ipcRenderer?.vaultReset?.() as { recoveryKey: string, config: AppConfig } | null;
         if (result) {
             setConfig(result.config);
             setRecoveryKeyModal(result.recoveryKey);

--- a/src/components/SFTPBrowser.tsx
+++ b/src/components/SFTPBrowser.tsx
@@ -199,8 +199,7 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig,
                         }
                     }
                     ipcRenderer?.sftpRealpath?.({id, path: '.'}).then((res: string) => {
-                        const resolvedPath = res;
-                        loadDirectory(resolvedPath, true);
+                        loadDirectory(res, true);
                     }).catch(() => loadDirectory('/', true));
                 }
             } else {

--- a/src/components/modals/NotificationModal.tsx
+++ b/src/components/modals/NotificationModal.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { CheckCircle2, AlertCircle, Info } from 'lucide-react';
-import type { NotificationType } from '../../types';
+import type { NotificationAction, NotificationType } from '../../types';
 
 interface NotificationModalProps {
     title: string;
     message: string;
     type?: NotificationType;
-    action?: { label: string, onClick: () => void, cancelLabel?: string };
+    action?: NotificationAction;
     onClose: () => void;
 }
 

--- a/src/components/views/SettingsView.tsx
+++ b/src/components/views/SettingsView.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { Settings, Monitor, Terminal, Keyboard, Info, RefreshCw, Download, UploadCloud, Database, Share2, Layout, Plus, Minus, ShieldCheck } from 'lucide-react';
-import type { AppConfig, NotificationType } from '../../types';
+import type { AppConfig, NotificationAction, NotificationType } from '../../types';
 import { VERSION } from '../../types';
 import { CustomSelect } from '../layout/CustomSelect';
 import { useUpdateChecker } from '../../hooks/useUpdateChecker';
@@ -13,7 +13,7 @@ interface SettingsViewProps {
     config: AppConfig;
     setConfig: (config: AppConfig | ((prev: AppConfig | null) => AppConfig | null)) => void;
     systemFonts: string[];
-    showNotification: (title: string, message: string, type?: NotificationType, action?: { label: string, onClick: () => void }) => void;
+    showNotification: (title: string, message: string, type?: NotificationType, action?: NotificationAction) => void;
     refreshVaultStatus: () => Promise<void>;
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -116,4 +116,11 @@ export interface Transfer {
 
 export type NotificationType = 'success' | 'error' | 'info';
 
+
+export interface NotificationAction {
+    label: string;
+    onClick: () => void;
+    cancelLabel?: string;
+}
+
 export const VERSION = '2.0.0';


### PR DESCRIPTION
### Motivation
- Исправить ошибку TypeScript `TS2353`, где объект действия уведомления содержал поле `cancelLabel`, отсутствующее в прежней сигнатуре. 
- Устранить `TS2345`, возникавшую при использовании `any` в коллбэках `setConfig` и при обработке результата `vaultInit`. 
- Объединить и упростить модель действия уведомления для единообразной и строгой типизации в UI. 

### Description
- Добавлен интерфейс `NotificationAction` в `src/types.ts` с полями `label`, `onClick` и опциональным `cancelLabel`. 
- В `src/components/views/SettingsView.tsx` обновлена сигнатура `showNotification` для использования `NotificationAction`, чтобы поддерживать `cancelLabel`. 
- В `src/components/modals/NotificationModal.tsx` заменён inline-тип `action` на `NotificationAction`. 
- В `src/App.tsx` уточнены типы: состояние `notification` теперь использует `NotificationAction`, коллбэки `setConfig` больше не приводятся к `any`, и результат `vaultInit` типизирован как `{ recoveryKey: string, config: AppConfig } | null`. 

### Testing
- До правок запущена команда `npm run -s typecheck`, которая завершилась с ошибкой на проблемных местах. 
- После внесённых правок выполнена проверка типов командой `npx tsc --noEmit`, которая завершилась успешно (exit code 0).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffa9d16844832aa47a7f93f8bbf28d)