### PR TITLE
Add Arch Linux build support and update README

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,6 +29,10 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Install Linux dependencies
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get update && sudo apt-get install -y libarchive-tools
+
       - name: Build and Release
         run: npm run package -- --publish always
         env:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,10 @@ YetAnotherSSHClient is a lightweight and fast open-source SSH client designed fo
   <img src="https://img.shields.io/badge/Linux-RPM-EE0000?style=for-the-badge&logo=redhat&logoColor=white" alt="Linux RPM"/>
 </a>
 
+<a href="https://github.com/megoRU/YetAnotherSSHClient/releases/latest/download/YASSHClient-linux-x86_64.pacman">
+  <img src="https://img.shields.io/badge/Linux-Pacman-1793D1?style=for-the-badge&logo=arch-linux&logoColor=white" alt="Linux Pacman"/>
+</a>
+
 <a href="https://github.com/megoRU/YetAnotherSSHClient/releases/latest/download/YASSHClient-macos-arm64.dmg">
   <img src="https://img.shields.io/badge/macOS-ARM64-000000?style=for-the-badge&logo=apple&logoColor=white" alt="macOS ARM64"/>
 </a>

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ YetAnotherSSHClient is a lightweight and fast open-source SSH client designed fo
   <img src="https://img.shields.io/badge/Linux-RPM-EE0000?style=for-the-badge&logo=redhat&logoColor=white" alt="Linux RPM"/>
 </a>
 
-<a href="https://github.com/megoRU/YetAnotherSSHClient/releases/latest/download/YASSHClient-linux-x86_64.pacman">
+<a href="https://github.com/megoRU/YetAnotherSSHClient/releases/latest/download/YASSHClient-linux-x64.pacman">
   <img src="https://img.shields.io/badge/Linux-Pacman-1793D1?style=for-the-badge&logo=arch-linux&logoColor=white" alt="Linux Pacman"/>
 </a>
 

--- a/package.json
+++ b/package.json
@@ -141,6 +141,13 @@
             "x64",
             "arm64"
           ]
+        },
+        {
+          "target": "pacman",
+          "arch": [
+            "x64",
+            "arm64"
+          ]
         }
       ],
       "artifactName": "YASSHClient-linux-${arch}.${ext}",


### PR DESCRIPTION
This PR adds support for building Arch Linux packages (.pacman) and updates the README.md with a corresponding download link and badge.

Key changes:
1.  **package.json**: Added `pacman` to the `linux.target` array, supporting both `x64` and `arm64` architectures.
2.  **README.md**: Added a new download badge for Arch Linux (Pacman) that follows the existing visual style and links to the latest release artifact.

---
*PR created automatically by Jules for task [16760691506639771947](https://jules.google.com/task/16760691506639771947) started by @megoRU*