### PR TITLE
Оптимизация terminal pipeline: IPC batching и batched render

### DIFF
--- a/electron/src/ipc-handlers.ts
+++ b/electron/src/ipc-handlers.ts
@@ -34,6 +34,60 @@ import {
     SSHConfig
 } from './types.js'
 
+interface OutputBatchState {
+    chunks: Buffer[]
+    totalLength: number
+    flushScheduled: boolean
+}
+
+const outputBatchMap = new Map<string, OutputBatchState>()
+const MAX_OUTPUT_BATCH_BYTES = 64 * 1024
+
+function flushOutputBatch(event: IpcMainEvent, id: string): void {
+    const state = outputBatchMap.get(id)
+    if (!state) {
+        return
+    }
+
+    state.flushScheduled = false
+
+    if (state.totalLength === 0 || state.chunks.length === 0) {
+        return
+    }
+
+    const payload = Buffer.concat(state.chunks, state.totalLength)
+    state.chunks = []
+    state.totalLength = 0
+    event.reply(`ssh-output-${id}`, payload)
+}
+
+function queueOutputChunk(event: IpcMainEvent, id: string, chunk: Buffer): void {
+    let state = outputBatchMap.get(id)
+    if (!state) {
+        state = {
+            chunks: [],
+            totalLength: 0,
+            flushScheduled: false
+        }
+        outputBatchMap.set(id, state)
+    }
+
+    state.chunks.push(chunk)
+    state.totalLength += chunk.length
+
+    if (state.totalLength >= MAX_OUTPUT_BATCH_BYTES) {
+        flushOutputBatch(event, id)
+        return
+    }
+
+    if (!state.flushScheduled) {
+        state.flushScheduled = true
+        setImmediate(() => {
+            flushOutputBatch(event, id)
+        })
+    }
+}
+
 /**
  * Форматирует ошибку SSH для отправки на фронтенд.
  * Позволяет фронтенду распознавать специфические ошибки (например, аутентификации).
@@ -109,6 +163,7 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
         shellStreams.delete(id)
         sshClients.delete(id)
         sshSockets.delete(id)
+        outputBatchMap.delete(id)
 
         const sshClient = new Client()
         sshClients.set(id, sshClient)
@@ -189,7 +244,7 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
                 shellStreams.set(id, stream)
 
                 stream.on('data', (chunk: Buffer) => {
-                    event.reply(`ssh-output-${id}`, chunk)
+                    queueOutputChunk(event, id, chunk)
                 })
 
                 if (config.initialCommands) {
@@ -206,6 +261,8 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
 
                 stream.on('close', () => {
                     console.log(`[SSH] Shell stream closed for ID: ${id}`)
+                    flushOutputBatch(event, id)
+                    outputBatchMap.delete(id)
                     sshClient.end()
                     event.reply(`ssh-status-${id}`, 'Соединение закрыто')
                 })
@@ -328,6 +385,7 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
 
     ipcMain.on('ssh-close', (_, id: string) => {
         if (typeof id !== 'string' || id.length > 64) return
+        outputBatchMap.delete(id)
         cleanupConnection(id)
     })
 

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -76,6 +76,10 @@ export const TerminalComponent: React.FC<Props> = ({
     const isMountedRef = useRef<boolean>(true);
     const wasConnectedRef = useRef<boolean>(false);
     const [countdown, setCountdown] = useState<number | null>(null);
+    const outputDecoderRef = useRef<TextDecoder>(new TextDecoder('utf-8'));
+    const outputQueueRef = useRef<string[]>([]);
+    const outputQueueBytesRef = useRef<number>(0);
+    const outputFlushRafIdRef = useRef<number | null>(null);
 
     // Вычисляемые свойства (Derived State)
     const isWaiting = !showTerminal;
@@ -293,13 +297,57 @@ export const TerminalComponent: React.FC<Props> = ({
             return result;
         };
 
+        const flushOutputQueue = () => {
+            outputFlushRafIdRef.current = null;
+            if (!isMountedRef.current) {
+                outputQueueRef.current = [];
+                outputQueueBytesRef.current = 0;
+                return;
+            }
+
+            if (outputQueueRef.current.length === 0) {
+                return;
+            }
+
+            const joinedOutput = outputQueueRef.current.join('');
+            outputQueueRef.current = [];
+            outputQueueBytesRef.current = 0;
+
+            try {
+                const highlighted = applyHighlighting(joinedOutput);
+                term.write(highlighted);
+            } catch (err) {
+                console.warn('[Terminal] batched write failed:', err);
+            }
+        };
+
+        const scheduleOutputFlush = () => {
+            if (outputFlushRafIdRef.current !== null) {
+                return;
+            }
+
+            outputFlushRafIdRef.current = window.requestAnimationFrame(() => {
+                flushOutputQueue();
+            });
+        };
+
         const onOutput = (data: Uint8Array) => {
             if (!isMountedRef.current) return;
             setHasReceivedData(true);
             try {
-                const text = new TextDecoder().decode(data);
-                const highlighted = applyHighlighting(text);
-                term.write(highlighted);
+                const text = outputDecoderRef.current.decode(data, { stream: true });
+                if (text.length > 0) {
+                    outputQueueRef.current.push(text);
+                    outputQueueBytesRef.current += data.byteLength;
+                }
+
+                const shouldFlushImmediately = outputQueueBytesRef.current >= 64 * 1024;
+                if (shouldFlushImmediately) {
+                    flushOutputQueue();
+                    return;
+                }
+
+                scheduleOutputFlush();
             } catch (err) {
                 console.warn('[Terminal] write failed:', err);
             }
@@ -354,6 +402,12 @@ export const TerminalComponent: React.FC<Props> = ({
             if (typeof unsubStatus === 'function') unsubStatus();
             if (typeof unsubError === 'function') unsubError();
             if (typeof unsubOSInfo === 'function') unsubOSInfo();
+            if (outputFlushRafIdRef.current !== null) {
+                window.cancelAnimationFrame(outputFlushRafIdRef.current);
+                outputFlushRafIdRef.current = null;
+            }
+            outputQueueRef.current = [];
+            outputQueueBytesRef.current = 0;
             try {
                 term.dispose();
             } catch { /* ignore */ }


### PR DESCRIPTION
### Motivation
- Снизить IPC-overhead и CPU/GC нагрузку при интенсивном выводе в терминал (heavy output / tail -f / большие логи). 
- Добиться более плавного рендера и меньшей задержки от получения данных до отрисовки в `xterm.js`.

### Description
- В `electron/src/ipc-handlers.ts` добавлен session-local батчинг SSH-выхода через `outputBatchMap`, объединение `Buffer`-чанков до 64KB и flush через `setImmediate`, а также принудительный flush при закрытии shell-потока и очистка состояния при `ssh-close`.
- В `src/components/Terminal.tsx` реализована очередь вывода с переиспользуемым `TextDecoder` (stream-режим), накопление строк и batched `term.write` через `requestAnimationFrame`, с немедленным flush при накоплении >= 64KB и очисткой RAF/очереди при unmount.
- Сохранены критические инварианты: `lineHeight: 1` и порядок инициализации (включая `fitAddon.fit()` до `sshConnect`), а также неизменная совместимость с TUI/ANSI/`xterm-256color`.
- Изменённые файлы: `electron/src/ipc-handlers.ts`, `src/components/Terminal.tsx`.

### Testing
- Запущен `npm run lint` — успешно (ESLint без ошибок, сборка не проверялась в этом PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c909bb6e8832abf4296760da3e40d)