### PR TITLE
Улучшение ИИ чата: выделение текста, скроллбар и обновление статуса в SupportView

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -809,6 +809,13 @@ input[type=number] {
     line-height: 1.5;
     position: relative;
     box-shadow: 0 2px 5px rgba(0,0,0,0.05);
+    user-select: text;
+    -webkit-user-select: text;
+}
+
+.message-bubble * {
+    user-select: text;
+    -webkit-user-select: text;
 }
 
 .message-wrapper.ai .message-bubble {

--- a/src/App.css
+++ b/src/App.css
@@ -831,6 +831,11 @@ input[type=number] {
     border-top-right-radius: 4px;
 }
 
+.message-wrapper.user .message-bubble ::selection {
+    background: rgba(255, 255, 255, 0.3);
+    color: white;
+}
+
 .message-footer {
     margin-top: 4px;
     display: flex;
@@ -964,17 +969,11 @@ input[type=number] {
 
 .typing-indicator-inline {
     display: inline-flex;
-    margin-left: 4px;
-    gap: 2px;
+    margin-left: 8px;
+    vertical-align: middle;
+    color: var(--text-secondary);
+    opacity: 0.8;
 }
-
-.typing-indicator-inline .dot {
-    animation: bounce 1.4s infinite ease-in-out both;
-    font-weight: bold;
-}
-
-.typing-indicator-inline .dot:nth-child(1) { animation-delay: -0.32s; }
-.typing-indicator-inline .dot:nth-child(2) { animation-delay: -0.16s; }
 
 /* Markdown & Code Block Styles */
 .text-content {

--- a/src/App.css
+++ b/src/App.css
@@ -831,11 +831,6 @@ input[type=number] {
     border-top-right-radius: 4px;
 }
 
-.message-wrapper.user .message-bubble ::selection {
-    background: rgba(255, 255, 255, 0.3);
-    color: white;
-}
-
 .message-footer {
     margin-top: 4px;
     display: flex;
@@ -969,11 +964,17 @@ input[type=number] {
 
 .typing-indicator-inline {
     display: inline-flex;
-    margin-left: 8px;
-    vertical-align: middle;
-    color: var(--text-secondary);
-    opacity: 0.8;
+    margin-left: 4px;
+    gap: 2px;
 }
+
+.typing-indicator-inline .dot {
+    animation: bounce 1.4s infinite ease-in-out both;
+    font-weight: bold;
+}
+
+.typing-indicator-inline .dot:nth-child(1) { animation-delay: -0.32s; }
+.typing-indicator-inline .dot:nth-child(2) { animation-delay: -0.16s; }
 
 /* Markdown & Code Block Styles */
 .text-content {

--- a/src/components/ai/ChatMessages.tsx
+++ b/src/components/ai/ChatMessages.tsx
@@ -20,7 +20,7 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({ messages, language, 
     }, [messages]);
 
     return (
-        <div className="chat-messages no-scrollbar">
+        <div className="chat-messages">
             {messages.map((msg) => (
                 <MessageBubble
                     key={msg.id}

--- a/src/components/ai/MessageBubble.tsx
+++ b/src/components/ai/MessageBubble.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Copy, User, Check } from 'lucide-react';
+import { Copy, User, Check, Loader2 } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
@@ -74,7 +74,7 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({ message, language,
                             </ReactMarkdown>
                             {message.isTyping && (
                                 <span className="typing-indicator-inline">
-                                    <span className="dot">.</span><span className="dot">.</span><span className="dot">.</span>
+                                    <Loader2 size={14} className="spin" />
                                 </span>
                             )}
                         </div>

--- a/src/components/ai/MessageBubble.tsx
+++ b/src/components/ai/MessageBubble.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Copy, User, Check, Loader2 } from 'lucide-react';
+import { Copy, User, Check } from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
@@ -74,7 +74,7 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({ message, language,
                             </ReactMarkdown>
                             {message.isTyping && (
                                 <span className="typing-indicator-inline">
-                                    <Loader2 size={14} className="spin" />
+                                    <span className="dot">.</span><span className="dot">.</span><span className="dot">.</span>
                                 </span>
                             )}
                         </div>

--- a/src/components/views/support/SupportView.tsx
+++ b/src/components/views/support/SupportView.tsx
@@ -84,6 +84,7 @@ export const SupportView: React.FC<SupportViewProps> = React.memo(({ config, sho
                             <ul>
                                 <li>SSH</li>
                                 <li>SFTP</li>
+                                <li>🤖 {t('support.aiAssistant')}</li>
                                 <li>{t('forward.title')}</li>
                                 <li>{t('settings.backup')}</li>
                                 <li>{t('settings.theme')}</li>
@@ -92,7 +93,6 @@ export const SupportView: React.FC<SupportViewProps> = React.memo(({ config, sho
                         <div className="progress-column">
                             <h3><Hammer size={16} className="icon-warning" /> {t('support.inDevelopment')}</h3>
                             <ul>
-                                <li>🤖 {t('support.aiAssistant')}</li>
                                 <li>✨ {t('support.commandCompletion')}</li>
                             </ul>
                         </div>


### PR DESCRIPTION
Улучшена работа с ИИ чатом: теперь пользователи могут выделять текст сообщений (как своих, так и ответов ИИ) мышкой. Также возвращена полоса прокрутки в окне чата для более удобной навигации по истории сообщений. В разделе «Поддержка» ИИ Помощник перенесен из списка разрабатываемых функций в список уже реализованных.

---
*PR created automatically by Jules for task [440992794304443544](https://jules.google.com/task/440992794304443544) started by @megoRU*