### PR TITLE
Исправление фокуса в ИИ Помощнике

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yetanothersshclient",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yetanothersshclient",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "dependencies": {
         "@xterm/addon-clipboard": "^0.2.0",
         "@xterm/addon-fit": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yetanothersshclient",
   "private": true,
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "A modern multi-platform SSH client built with React and Electron",
   "repository": {
     "type": "git",

--- a/src/App.css
+++ b/src/App.css
@@ -831,6 +831,11 @@ input[type=number] {
     border-top-right-radius: 4px;
 }
 
+.message-wrapper.user .message-bubble ::selection {
+    background: rgba(255, 255, 255, 0.3);
+    color: white;
+}
+
 .message-footer {
     margin-top: 4px;
     display: flex;

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -473,10 +473,10 @@ export const TerminalComponent: React.FC<Props> = ({
     }, [status, isAuthFailed, t]);
 
     useEffect(() => {
-        if (visible && isMountedRef.current) {
+        if (visible && isMountedRef.current && !aiOpen) {
             safeFit();
             setTimeout(() => {
-                if (isMountedRef.current && xtermRef.current) {
+                if (isMountedRef.current && xtermRef.current && !aiOpen) {
                     xtermRef.current.focus();
                 }
             }, 50);
@@ -725,7 +725,8 @@ export const TerminalComponent: React.FC<Props> = ({
                     onClose={onToggleAi || (() => {})}
                     language={appConfig?.language || 'ru'}
                     osPrettyName={config.osPrettyName}
-                focusTrigger={aiFocusTrigger}
+                    focusTrigger={aiFocusTrigger}
+                    visible={aiOpen}
                 />
             </div>
         )}

--- a/src/components/ai/AIChatPanel.tsx
+++ b/src/components/ai/AIChatPanel.tsx
@@ -14,6 +14,7 @@ interface AIChatPanelProps {
     language: 'ru' | 'en';
     osPrettyName?: string;
     focusTrigger?: number;
+    visible?: boolean;
 }
 
 export const AIChatPanel: React.FC<AIChatPanelProps> = ({
@@ -22,16 +23,22 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
     onClose,
     language,
     osPrettyName,
-    focusTrigger
+    focusTrigger,
+    visible
 }) => {
     const { t } = useI18n(language);
     const [isLoading, setIsLoading] = useState(false);
     const chatInputRef = useRef<HTMLTextAreaElement>(null);
 
     useEffect(() => {
-        // Focus input on mount or when trigger changes
-        chatInputRef.current?.focus();
-    }, [focusTrigger]);
+        // Focus input on mount, when trigger changes, or when becoming visible/not loading
+        if (visible && !isLoading) {
+            const timer = setTimeout(() => {
+                chatInputRef.current?.focus();
+            }, 50);
+            return () => clearTimeout(timer);
+        }
+    }, [focusTrigger, visible, isLoading]);
 
     const handleSendMessage = async (content: string) => {
         const userMessage: ChatMessage = {

--- a/src/components/ai/MessageBubble.tsx
+++ b/src/components/ai/MessageBubble.tsx
@@ -13,16 +13,50 @@ interface MessageBubbleProps {
     onCopy: (text: string) => void;
 }
 
+interface CodeBlockProps {
+    language: string;
+    code: string;
+    onCopy: (text: string) => void;
+}
+
+const CodeBlock: React.FC<CodeBlockProps> = ({ language, code, onCopy }) => {
+    const [copied, setCopied] = React.useState(false);
+
+    const handleCopy = () => {
+        onCopy(code);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+    };
+
+    return (
+        <div className="code-block-container">
+            <div className="code-block-header">
+                <span>{language}</span>
+                <button className="code-copy-btn" onClick={handleCopy}>
+                    {copied ? <Check size={14} /> : <Copy size={14} />}
+                </button>
+            </div>
+            <SyntaxHighlighter
+                style={vscDarkPlus as Record<string, { [key: string]: React.CSSProperties }>}
+                language={language}
+                PreTag="div"
+            >
+                {code}
+            </SyntaxHighlighter>
+        </div>
+    );
+};
+
 export const MessageBubble: React.FC<MessageBubbleProps> = ({ message, language, onCopy }) => {
     const { t } = useI18n(language);
-    const [copied, setCopied] = React.useState(false);
+    const [messageCopied, setMessageCopied] = React.useState(false);
     const isUser = message.role === 'user';
     const time = new Date(message.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
 
-    const handleCopy = (text: string) => {
-        onCopy(text);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
+    const handleCopyMessage = () => {
+        onCopy(message.content);
+        setMessageCopied(true);
+        setTimeout(() => setMessageCopied(false), 2000);
     };
 
     return (
@@ -43,25 +77,11 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({ message, language,
                                         const codeString = String(children).replace(/\n$/, '');
 
                                         return !isInline ? (
-                                            <div className="code-block-container">
-                                                <div className="code-block-header">
-                                                    <span>{match ? match[1] : 'code'}</span>
-                                                    <button
-                                                        className="code-copy-btn"
-                                                        onClick={() => handleCopy(codeString)}
-                                                    >
-                                                        {copied ? <Check size={14} /> : <Copy size={14} />}
-                                                    </button>
-                                                </div>
-                                                <SyntaxHighlighter
-                                                    style={vscDarkPlus as Record<string, { [key: string]: React.CSSProperties }>}
-                                                    language={match ? match[1] : 'text'}
-                                                    PreTag="div"
-                                                    {...(props as Record<string, unknown>)}
-                                                >
-                                                    {codeString}
-                                                </SyntaxHighlighter>
-                                            </div>
+                                            <CodeBlock
+                                                language={match ? match[1] : 'text'}
+                                                code={codeString}
+                                                onCopy={onCopy}
+                                            />
                                         ) : (
                                             <code className={className} {...props}>
                                                 {children}
@@ -85,8 +105,8 @@ export const MessageBubble: React.FC<MessageBubbleProps> = ({ message, language,
                 </div>
                 {!isUser && !message.isTyping && (
                     <div className="message-actions">
-                        <button className="action-btn" onClick={() => handleCopy(message.content)}>
-                            {copied ? <Check size={14} /> : <Copy size={14} />}
+                        <button className="action-btn" onClick={handleCopyMessage}>
+                            {messageCopied ? <Check size={14} /> : <Copy size={14} />}
                             <span>{t('ai.copy')}</span>
                         </button>
                     </div>

--- a/src/hooks/useTabs.ts
+++ b/src/hooks/useTabs.ts
@@ -44,7 +44,12 @@ export const useTabs = (initialTabs: Tab[]) => {
     const toggleAi = useCallback((id: string) => {
         setTabs(prev => prev.map(tab => {
             if (tab.id === id) {
-                return { ...tab, aiOpen: !tab.aiOpen };
+                const newAiOpen = !tab.aiOpen;
+                return {
+                    ...tab,
+                    aiOpen: newAiOpen,
+                    aiFocusTrigger: newAiOpen ? Date.now() : tab.aiFocusTrigger
+                };
             }
             return tab;
         }));

--- a/src/types.ts
+++ b/src/types.ts
@@ -135,4 +135,4 @@ export interface NotificationAction {
     cancelLabel?: string;
 }
 
-export const VERSION = '2.3.0';
+export const VERSION = '2.3.1';


### PR DESCRIPTION
Исправлена проблема, при которой фокус на поле ввода в чате с ИИ пропадал после отправки сообщения и получения ответа. Также реализована автоматическая установка фокуса при открытии панели ИИ-помощника.

Основные изменения:
1.  **useTabs.ts**: Теперь `toggleAi` также обновляет `aiFocusTrigger` при открытии панели, что позволяет ИИ-чату узнать о необходимости установить фокус.
2.  **AIChatPanel.tsx**: Эффект установки фокуса теперь срабатывает не только при изменении триггера, но и когда `isLoading` становится `false` (после ответа ИИ) или когда панель становится `visible`. Использование `setTimeout` на 50мс гарантирует, что фокус не будет «украден» другими элементами в процессе рендеринга.
3.  **Terminal.tsx**: Добавлено условие `!aiOpen` в обработчик фокуса терминала. Это предотвращает автоматический возврат фокуса в консоль, когда пользователь взаимодействует с ИИ-помощником.

---
*PR created automatically by Jules for task [12937016962007188587](https://jules.google.com/task/12937016962007188587) started by @megoRU*