### PR TITLE
Bump version to 2.3.3 and improve AI chat copy logic

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yetanothersshclient",
-  "version": "2.3.2",
+  "version": "2.3.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yetanothersshclient",
-      "version": "2.3.2",
+      "version": "2.3.3",
       "dependencies": {
         "@xterm/addon-clipboard": "^0.2.0",
         "@xterm/addon-fit": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yetanothersshclient",
   "private": true,
-  "version": "2.3.2",
+  "version": "2.3.3",
   "description": "A modern multi-platform SSH client built with React and Electron",
   "repository": {
     "type": "git",

--- a/src/components/Terminal.tsx
+++ b/src/components/Terminal.tsx
@@ -727,6 +727,7 @@ export const TerminalComponent: React.FC<Props> = ({
                     osPrettyName={config.osPrettyName}
                     focusTrigger={aiFocusTrigger}
                     visible={aiOpen}
+                    theme={theme}
                 />
             </div>
         )}

--- a/src/components/ai/AIChatPanel.tsx
+++ b/src/components/ai/AIChatPanel.tsx
@@ -15,6 +15,7 @@ interface AIChatPanelProps {
     osPrettyName?: string;
     focusTrigger?: number;
     visible?: boolean;
+    theme?: string;
 }
 
 export const AIChatPanel: React.FC<AIChatPanelProps> = ({
@@ -24,7 +25,8 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
     language,
     osPrettyName,
     focusTrigger,
-    visible
+    visible,
+    theme
 }) => {
     const { t } = useI18n(language);
     const [isLoading, setIsLoading] = useState(false);
@@ -160,6 +162,7 @@ export const AIChatPanel: React.FC<AIChatPanelProps> = ({
                 messages={messages}
                 language={language}
                 onCopy={handleCopy}
+                theme={theme}
             />
             <ChatInput
                 ref={chatInputRef}

--- a/src/components/ai/ChatMessages.tsx
+++ b/src/components/ai/ChatMessages.tsx
@@ -6,12 +6,14 @@ interface ChatMessagesProps {
     messages: ChatMessage[];
     language: 'ru' | 'en';
     onCopy: (text: string) => void;
+    theme?: string;
 }
 
 export const ChatMessages: React.FC<ChatMessagesProps> = ({
                                                               messages,
                                                               language,
                                                               onCopy,
+                                                              theme
                                                           }) => {
     const containerRef = useRef<HTMLDivElement>(null);
     const shouldAutoScrollRef = useRef(true);
@@ -75,6 +77,7 @@ export const ChatMessages: React.FC<ChatMessagesProps> = ({
                     message={msg}
                     language={language}
                     onCopy={onCopy}
+                    theme={theme}
                 />
             ))}
         </div>

--- a/src/components/ai/MessageBubble.tsx
+++ b/src/components/ai/MessageBubble.tsx
@@ -1,6 +1,9 @@
-import React from 'react';
+import React, {useState} from 'react';
 import {Check, Copy, User} from 'lucide-react';
 import ReactMarkdown from 'react-markdown';
+import {Prism as SyntaxHighlighter} from 'react-syntax-highlighter';
+import {vscDarkPlus, prism} from 'react-syntax-highlighter/dist/esm/styles/prism';
+import remarkGfm from 'remark-gfm';
 import type {ChatMessage} from "../../types.ts";
 import {useI18n} from "../../utils/i18n.ts";
 
@@ -8,15 +11,82 @@ interface MessageBubbleProps {
     message: ChatMessage;
     language: 'ru' | 'en';
     onCopy: (text: string) => void;
+    theme?: string;
 }
 
-export const MessageBubble = React.memo(function MessageBubble({message, language, onCopy,}: MessageBubbleProps) {
+interface CodeBlockProps {
+    language: string;
+    value: string;
+    isTyping?: boolean;
+    theme?: string;
+    onCopy: (text: string) => void;
+    t: (key: string) => string;
+}
+
+const CodeBlock = React.memo(({language, value, isTyping, theme, onCopy, t}: CodeBlockProps) => {
+    const [copied, setCopied] = useState(false);
+
+    const handleCopy = (e: React.MouseEvent) => {
+        e.stopPropagation();
+        onCopy(value);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+    };
+
+    const isDark = theme !== 'light';
+    const syntaxTheme = isDark ? vscDarkPlus : prism;
+
+    return (
+        <div className="code-block-container">
+            <div className="code-block-header">
+                <span className="code-block-lang">{language || 'text'}</span>
+                <button className="code-copy-btn" onClick={handleCopy} title={t('ai.copy')}>
+                    {copied ? <Check size={14}/> : <Copy size={14}/>}
+                </button>
+            </div>
+            <div className="code-block-content">
+                {isTyping ? (
+                    <pre><code>{value}</code></pre>
+                ) : (
+                    <SyntaxHighlighter
+                        language={language || 'text'}
+                        style={syntaxTheme}
+                        PreTag="div"
+                        customStyle={{
+                            margin: 0,
+                            padding: '12px',
+                            background: 'transparent',
+                            fontSize: 'var(--ui-font-size)',
+                        }}
+                    >
+                        {value}
+                    </SyntaxHighlighter>
+                )}
+            </div>
+        </div>
+    );
+});
+
+export const MessageBubble = React.memo(function MessageBubble({message, language, onCopy, theme}: MessageBubbleProps) {
     const {t} = useI18n(language);
     const [messageCopied, setMessageCopied] = React.useState(false);
     const isUser = message.role === 'user';
 
     const handleCopyMessage = () => {
-        onCopy(message.content);
+        // Регулярка для поиска всех блоков кода
+        const codeBlockRegex = /```(?:\w+)?\s*\n?([\s\S]*?)\n?```/g;
+        const matches = Array.from(message.content.matchAll(codeBlockRegex));
+
+        if (matches.length > 0) {
+            // Если есть блоки кода, копируем только их содержимое, разделяя двойным переносом
+            const codeOnly = matches.map(match => match[1].trim()).join('\n\n');
+            onCopy(codeOnly);
+        } else {
+            // Если блоков кода нет, копируем весь текст, но убираем инлайновые `
+            const cleanText = message.content.replace(/`([^`]+)`/g, '$1');
+            onCopy(cleanText);
+        }
+
         setMessageCopied(true);
         setTimeout(() => setMessageCopied(false), 2000);
     };
@@ -29,9 +99,38 @@ export const MessageBubble = React.memo(function MessageBubble({message, languag
             <div className="message-container">
                 <div className="message-bubble">
                     <div className="message-content">
-                        <div className="text-content">
+                        <div className={`text-content ${message.isTyping ? 'typing' : ''}`}>
+                            <ReactMarkdown
+                                remarkPlugins={[remarkGfm]}
+                                components={{
+                                    code({inline, className, children, ...props}: any) {
+                                        const match = /language-(\w+)/.exec(className || '');
+                                        const lang = match ? match[1] : '';
+                                        const value = String(children).replace(/\n$/, '');
 
-                            <ReactMarkdown>{message.content}</ReactMarkdown>
+                                        if (!inline) {
+                                            return (
+                                                <CodeBlock
+                                                    language={lang}
+                                                    value={value}
+                                                    isTyping={message.isTyping}
+                                                    theme={theme}
+                                                    onCopy={onCopy}
+                                                    t={t}
+                                                />
+                                            );
+                                        }
+
+                                        return (
+                                            <code className={className} {...props}>
+                                                {children}
+                                            </code>
+                                        );
+                                    }
+                                }}
+                            >
+                                {message.content}
+                            </ReactMarkdown>
                         </div>
                     </div>
                 </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -135,4 +135,4 @@ export interface NotificationAction {
     cancelLabel?: string;
 }
 
-export const VERSION = '2.3.2';
+export const VERSION = '2.3.3';


### PR DESCRIPTION
Bumps application version to 2.3.3 and improves the user experience in AI Assistant by refining how code is displayed and copied. Code blocks now have independent copy buttons, and the main message copy button extracts only the actual code from markdown blocks.

---
*PR created automatically by Jules for task [4185848748787810508](https://jules.google.com/task/4185848748787810508) started by @megoRU*