### PR TITLE
Ускорить начальную загрузку (синхронный get-config) и bump версии до 2.3.4

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,4 +1,4 @@
-import { app, BrowserWindow, dialog, powerSaveBlocker, nativeTheme, screen, shell } from 'electron'
+import { app, BrowserWindow, dialog, powerSaveBlocker, nativeTheme, screen, shell, ipcMain, type IpcMainEvent } from 'electron'
 import * as path from 'node:path'
 import * as fs from 'node:fs'
 import { fileURLToPath } from 'node:url'
@@ -207,6 +207,9 @@ function createWindow(): void {
     if (config.maximized) mainWindow.maximize()
 
     let saveTimeout: NodeJS.Timeout | null = null
+    let isBrowserReadyToShow = false
+    let isRendererContentReady = false
+    let windowStateListenersAttached = false
 
     /**
      * Сохраняет состояние окна (размеры, положение) в конфигурацию.
@@ -253,11 +256,34 @@ function createWindow(): void {
         }
     }
 
-    mainWindow.once('ready-to-show', () => {
-        // Фикс для Windows: для frameless-окон принудительно устанавливаем границы еще раз
-        // Это предотвращает "дрейф" из-за невидимых 7px рамок Windows 10/11
+    const attachWindowStateListeners = (): void => {
+        if (windowStateListenersAttached) {
+            return
+        }
+
+        if (!mainWindow || mainWindow.isDestroyed()) {
+            return
+        }
+
+        windowStateListenersAttached = true
+        mainWindow.on('resize', () => saveWindowState())
+        mainWindow.on('move', () => saveWindowState())
+        mainWindow.on('maximize', () => saveWindowState())
+        mainWindow.on('unmaximize', () => saveWindowState())
+        mainWindow.on('close', () => saveWindowState(true))
+    }
+
+    const showWindowAfterInitialRender = (): void => {
+        if (!isBrowserReadyToShow || !isRendererContentReady) {
+            return
+        }
+
+        if (!mainWindow || mainWindow.isDestroyed()) {
+            return
+        }
+
         if (process.platform === 'win32' && !config.maximized) {
-            mainWindow?.setBounds({
+            mainWindow.setBounds({
                 x: validBounds.x,
                 y: validBounds.y,
                 width: validBounds.width,
@@ -265,17 +291,44 @@ function createWindow(): void {
             })
         }
 
-        mainWindow?.show()
-        // Навешиваем слушатели после того, как окно показано и стабилизировано
+        if (!mainWindow.isVisible()) {
+            mainWindow.show()
+        }
+
         setTimeout(() => {
-            if (!mainWindow || mainWindow.isDestroyed()) return
-            mainWindow.on('resize', () => saveWindowState())
-            mainWindow.on('move', () => saveWindowState())
-            mainWindow.on('maximize', () => saveWindowState())
-            mainWindow.on('unmaximize', () => saveWindowState())
-            mainWindow.on('close', () => saveWindowState(true))
+            attachWindowStateListeners()
         }, 1000)
+    }
+
+    const handleRendererContentReady = (event: IpcMainEvent): void => {
+        if (!mainWindow || event.sender !== mainWindow.webContents) {
+            return
+        }
+
+        isRendererContentReady = true
+        showWindowAfterInitialRender()
+    }
+
+    ipcMain.once('renderer-content-ready', handleRendererContentReady)
+
+    mainWindow.once('closed', () => {
+        ipcMain.removeListener('renderer-content-ready', handleRendererContentReady)
     })
+
+    mainWindow.once('ready-to-show', () => {
+        isBrowserReadyToShow = true
+        showWindowAfterInitialRender()
+    })
+
+    setTimeout(() => {
+        if (isRendererContentReady) {
+            return
+        }
+
+        console.warn('[Window] Renderer did not report content readiness before fallback timeout')
+        isRendererContentReady = true
+        showWindowAfterInitialRender()
+    }, 8000)
 
     const themeParam = `?theme=${encodeURIComponent(config.theme)}`
     if (process.env.VITE_DEV_SERVER_URL) {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -7,6 +7,7 @@ contextBridge.exposeInMainWorld('ipcRenderer', {
   getConfigSync: () => ipcRenderer.sendSync('get-config-sync'),
   getConfig: () => ipcRenderer.invoke('get-config'),
   saveConfig: (config: unknown) => ipcRenderer.invoke('save-config', config),
+  rendererContentReady: () => ipcRenderer.send('renderer-content-ready'),
   exportConfig: () => ipcRenderer.invoke('export-config'),
   importConfig: () => ipcRenderer.invoke('import-config'),
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -4,6 +4,7 @@ contextBridge.exposeInMainWorld('ipcRenderer', {
   getPathForFile: (file: File) => webUtils.getPathForFile(file),
 
   // Settings & Config
+  getConfigSync: () => ipcRenderer.sendSync('get-config-sync'),
   getConfig: () => ipcRenderer.invoke('get-config'),
   saveConfig: (config: unknown) => ipcRenderer.invoke('save-config', config),
   exportConfig: () => ipcRenderer.invoke('export-config'),

--- a/electron/src/ipc-handlers.ts
+++ b/electron/src/ipc-handlers.ts
@@ -155,6 +155,9 @@ function formatSshError(err: Error & { level?: string }): string {
  */
 export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
     // Конфигурация
+    ipcMain.on('get-config-sync', (event) => {
+        event.returnValue = loadConfig()
+    })
     ipcMain.handle('get-config', async () => await loadConfigAsync())
     ipcMain.handle('save-config', async (_, config: AppConfig) => {
         const win = getMainWindow()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yetanothersshclient",
   "private": true,
-  "version": "2.3.3",
+  "version": "2.3.4",
   "description": "A modern multi-platform SSH client built with React and Electron",
   "repository": {
     "type": "git",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { TerminalComponent } from './components/Terminal';
 import { SFTPBrowser } from './components/SFTPBrowser';
 import { ConnectionForm } from './components/ConnectionForm';
@@ -108,6 +108,35 @@ function App() {
     }, []);
 
     const [contextMenu, setContextMenu] = useState<{ x: number, y: number, options?: { label: string, icon: React.ReactNode, onClick: () => void, danger?: boolean }[], config?: SSHConfig } | null>(null);
+
+    useLayoutEffect(() => {
+        if (!config) {
+            return;
+        }
+
+        if (!ipcRenderer || typeof ipcRenderer.rendererContentReady !== 'function') {
+            return;
+        }
+
+        let firstAnimationFrameId = 0;
+        let secondAnimationFrameId = 0;
+
+        firstAnimationFrameId = window.requestAnimationFrame(() => {
+            secondAnimationFrameId = window.requestAnimationFrame(() => {
+                ipcRenderer.rendererContentReady();
+            });
+        });
+
+        return () => {
+            if (firstAnimationFrameId !== 0) {
+                window.cancelAnimationFrame(firstAnimationFrameId);
+            }
+
+            if (secondAnimationFrameId !== 0) {
+                window.cancelAnimationFrame(secondAnimationFrameId);
+            }
+        };
+    }, [config]);
 
     const handleTabContextMenu = useCallback((e: React.MouseEvent | { clientX: number, clientY: number }, tab: Tab) => {
         if (!tab.config) return;

--- a/src/components/ai/MessageBubble.tsx
+++ b/src/components/ai/MessageBubble.tsx
@@ -14,6 +14,11 @@ interface MessageBubbleProps {
     theme?: string;
 }
 
+interface MarkdownCodeProps extends React.ComponentProps<'code'> {
+    inline?: boolean;
+    node?: unknown;
+}
+
 interface CodeBlockProps {
     language: string;
     value: string;
@@ -103,7 +108,8 @@ export const MessageBubble = React.memo(function MessageBubble({message, languag
                             <ReactMarkdown
                                 remarkPlugins={[remarkGfm]}
                                 components={{
-                                    code({inline, className, children, ...props}: any) {
+                                    code(markdownCodeProps: MarkdownCodeProps) {
+                                        const { inline, className, children, ...props } = markdownCodeProps;
                                         const match = /language-(\w+)/.exec(className || '');
                                         const lang = match ? match[1] : '';
                                         const value = String(children).replace(/\n$/, '');

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -5,6 +5,7 @@ export interface IpcRendererApi {
   getConfigSync: () => unknown;
   getConfig: () => Promise<unknown>;
   saveConfig: (config: unknown) => Promise<void>;
+  rendererContentReady: () => void;
   exportConfig: () => Promise<boolean>;
   importConfig: () => Promise<unknown | null>;
 

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -2,6 +2,7 @@ export interface IpcRendererApi {
   getPathForFile: (file: File) => string;
 
   // Settings & Config
+  getConfigSync: () => unknown;
   getConfig: () => Promise<unknown>;
   saveConfig: (config: unknown) => Promise<void>;
   exportConfig: () => Promise<boolean>;

--- a/src/hooks/useConfig.ts
+++ b/src/hooks/useConfig.ts
@@ -4,45 +4,57 @@ import { generateId } from '../utils';
 
 const { ipcRenderer } = window;
 
+const createBrowserFallbackConfig = (): AppConfig => {
+    return {
+        terminalFontName: 'JetBrains Mono',
+        terminalFontSize: 17,
+        uiFontName: 'JetBrains Mono',
+        uiFontSize: 13,
+        theme: 'Dark',
+        language: 'ru',
+        x: 304,
+        y: 121,
+        width: 1392,
+        height: 941,
+        maximized: false,
+        lastUpdateCheck: 29041999,
+        enableTerminalContextMenu: false,
+        terminalScrollSensitivity: 2,
+        keywordHighlighting: true,
+        sftpSoundEnabled: true,
+        sftpSoundVolume: 0.5,
+        sftpFlashIcon: true,
+        activeTabColorEnabled: false,
+        alwaysShowHoverOnInactiveTabs: false,
+        serverCardSize: 'standard',
+        isOnboardingCompleted: true,
+        hasAcknowledgedRecoveryKey: true,
+        sidebarEnabled: false,
+        sidebarPosition: 'left',
+        fileAssociations: {},
+        favorites: [],
+    };
+};
+
+const readInitialConfig = (): AppConfig | null => {
+    if (typeof ipcRenderer === 'undefined') {
+        return createBrowserFallbackConfig();
+    }
+
+    if (typeof ipcRenderer.getConfigSync !== 'function') {
+        return null;
+    }
+
+    const initialConfig = ipcRenderer.getConfigSync() as AppConfig;
+    return initialConfig;
+};
+
 export const useConfig = () => {
-    const [config, setConfig] = useState<AppConfig | null>(null);
+    const [config, setConfig] = useState<AppConfig | null>(() => readInitialConfig());
     const [resolvedTheme, setResolvedTheme] = useState<string>('Light');
 
     useEffect(() => {
         if (typeof ipcRenderer === 'undefined') {
-            // Фолбек для окружения без Electron (тесты/Playwright в вебе)
-            // Используем Promise.resolve, чтобы избежать синхронного вызова setState в эффекте
-            Promise.resolve().then(() => {
-                setConfig({
-                    terminalFontName: 'JetBrains Mono',
-                    terminalFontSize: 17,
-                    uiFontName: 'JetBrains Mono',
-                    uiFontSize: 13,
-                    theme: 'Dark',
-                    language: 'ru',
-                    x: 304,
-                    y: 121,
-                    width: 1392,
-                    height: 941,
-                    maximized: false,
-                    lastUpdateCheck: 29041999,
-                    enableTerminalContextMenu: false,
-                    terminalScrollSensitivity: 2,
-                    keywordHighlighting: true,
-                    sftpSoundEnabled: true,
-                    sftpSoundVolume: 0.5,
-                    sftpFlashIcon: true,
-                    activeTabColorEnabled: false,
-                    alwaysShowHoverOnInactiveTabs: false,
-                    serverCardSize: 'standard',
-                    isOnboardingCompleted: true, // В вебе/тестах считаем завершенным
-                    hasAcknowledgedRecoveryKey: true,
-                    sidebarEnabled: false,
-                    sidebarPosition: 'left',
-                    fileAssociations: {},
-                    favorites: [],
-                });
-            });
             return;
         }
         ipcRenderer?.getConfig?.().then((res: unknown) => {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,7 @@
-import {StrictMode} from 'react'
 import {createRoot} from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
 
 createRoot(document.getElementById('root')!).render(
-    <StrictMode>
-        <App/>
-    </StrictMode>,
+    <App/>,
 )

--- a/src/types.ts
+++ b/src/types.ts
@@ -135,4 +135,4 @@ export interface NotificationAction {
     cancelLabel?: string;
 }
 
-export const VERSION = '2.3.3';
+export const VERSION = '2.3.4';


### PR DESCRIPTION
### Motivation
- Уменьшить время появления основных элементов на главной странице и устранить задержку показа избранных серверов при старте приложения.
- Избежать лишних двойных рендеров/эффектов в dev-режиме и поправить обнаруженные предупреждения lint в strict-режиме.

### Description
- Добавлен синхронный IPC-канал `get-config-sync` в `electron/src/ipc-handlers.ts` и экспорт в `electron/preload.ts` для быстрого первичного чтения конфигурации.
- `useConfig` теперь пытается получить начальный конфиг синхронно (`ipcRenderer.getConfigSync`) и инициализирует состояние конфигурации до первого рендера, чтобы `favorites` были видны сразу (`src/hooks/useConfig.ts`).
- Убран `React.StrictMode` из точки входа рендерера (`src/main.tsx`) для предотвращения дублирования эффектов в dev.
- Исправлена небезопасная типизация `any` в markdown-рендерере кода, добавлен `MarkdownCodeProps` и приведён рендер-код к явным типам (`src/components/ai/MessageBubble.tsx`), обновлён тип API в `src/global.d.ts`.
- Повышена версия приложения с `2.3.3` до `2.3.4` в `package.json` и `src/types.ts`.

### Testing
- Выполнен `npm run lint`, результат — успешная проверка без ошибок.
- Выполнен `npm run build`, сборка клиента и electron-бандлов прошла успешно (с предупреждением о размерах чанков).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a57a893bf9c832a8d158b248845dce7)