### PR TITLE
Отображение скрытых файлов в SFTP и bump версии 2.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yetanothersshclient",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yetanothersshclient",
-      "version": "2.4.0",
+      "version": "2.4.1",
       "dependencies": {
         "@xterm/addon-clipboard": "^0.2.0",
         "@xterm/addon-fit": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yetanothersshclient",
   "private": true,
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "A modern multi-platform SSH client built with React and Electron",
   "repository": {
     "type": "git",

--- a/src/components/SFTPBrowser.tsx
+++ b/src/components/SFTPBrowser.tsx
@@ -198,7 +198,7 @@ export const SFTPBrowser: React.FC<Props> = ({id, config, visible, onEditConfig,
             // Больше не удаляем успешно завершенные трансферы автоматически,
             // чтобы пользователь видел историю операций в списке задач.
 
-            let filteredList = (list || []).filter((f: SftpFileEntry) => !f.filename.startsWith('.'));
+            let filteredList = (list || []).filter((f: SftpFileEntry) => f.filename !== '.' && f.filename !== '..');
             filteredList.sort((a, b) => {
                 const aMode = a.attrs.mode;
                 const bMode = b.attrs.mode;

--- a/src/types.ts
+++ b/src/types.ts
@@ -135,4 +135,4 @@ export interface NotificationAction {
     cancelLabel?: string;
 }
 
-export const VERSION = '2.4.0';
+export const VERSION = '2.4.1';


### PR DESCRIPTION
Исправлена фильтрация элементов директории в SFTPBrowser.tsx: теперь фильтруются только спецдиректории '.' и '..', а скрытые файлы и папки (начинающиеся с точки) отображаются в файловом менеджере. Обновлена версия приложения до 2.4.1.

---
*PR created automatically by Jules for task [9931927417227056932](https://jules.google.com/task/9931927417227056932) started by @megoRU*