### PR TITLE
Bump version 2.5.4 and fix update status font scaling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yetanothersshclient",
-  "version": "2.5.3",
+  "version": "2.5.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yetanothersshclient",
-      "version": "2.5.3",
+      "version": "2.5.4",
       "dependencies": {
         "@xterm/addon-clipboard": "^0.2.0",
         "@xterm/addon-fit": "^0.11.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yetanothersshclient",
   "private": true,
-  "version": "2.5.3",
+  "version": "2.5.4",
   "description": "A modern multi-platform SSH client built with React and Electron",
   "repository": {
     "type": "git",

--- a/src/components/views/settings/AboutSection.tsx
+++ b/src/components/views/settings/AboutSection.tsx
@@ -33,7 +33,6 @@ export const AboutSection: React.FC<AboutSectionProps> = React.memo(({
     startDownload,
     quitAndInstall,
     manualCheckResult,
-    stripHtml,
     ipcRenderer,
     t
 }) => {
@@ -88,7 +87,7 @@ export const AboutSection: React.FC<AboutSectionProps> = React.memo(({
                         <span style={{ fontSize: '1.2rem', fontWeight: 600, color: 'var(--text-primary)' }}>YetAnotherSSHClient</span>
                         <span style={{ fontSize: '0.95rem', color: 'var(--text-secondary)', fontWeight: 500 }}>v{VERSION}</span>
                     </div>
-                    <div className="settings-description" style={{ fontSize: '0.875rem', color: 'var(--text-secondary)' }}>
+                    <div className="settings-description" style={{ color: 'var(--text-secondary)' }}>
                         {getUpdateStatusText()}
                     </div>
                 </div>

--- a/src/types.ts
+++ b/src/types.ts
@@ -136,4 +136,4 @@ export interface NotificationAction {
     cancelLabel?: string;
 }
 
-export const VERSION = '2.5.3';
+export const VERSION = '2.5.4';


### PR DESCRIPTION
Bumped application version to 2.5.4 and updated AboutSection to scale the update status description font size dynamically based on global UI font size settings.

---
*PR created automatically by Jules for task [15442278964424258238](https://jules.google.com/task/15442278964424258238) started by @megoRU*