### PR TITLE
bump version to 2.6.8 and support user_profile_url_image

### DIFF
--- a/electron/src/types.ts
+++ b/electron/src/types.ts
@@ -1,4 +1,4 @@
-export const VERSION = '2.6.7'
+export const VERSION = '2.6.8'
 
 /**
  * Конфигурация SSH-сервера

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "yetanothersshclient",
-  "version": "2.6.7",
+  "version": "2.6.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yetanothersshclient",
-      "version": "2.6.7",
+      "version": "2.6.8",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.30.0",
         "@xterm/addon-clipboard": "^0.2.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "yetanothersshclient",
   "private": true,
-  "version": "2.6.7",
+  "version": "2.6.8",
   "description": "A modern multi-platform SSH client built with React and Electron",
   "repository": {
     "type": "git",

--- a/src/components/views/support/SupportView.tsx
+++ b/src/components/views/support/SupportView.tsx
@@ -22,6 +22,7 @@ interface Supporter {
 interface ApiUser {
     user_name?: string;
     user_tier?: string;
+    user_profile_url_image?: string | null;
 }
 
 export const SupportView: React.FC<SupportViewProps> = React.memo(({ config, setConfig, showNotification }) => {
@@ -47,7 +48,7 @@ export const SupportView: React.FC<SupportViewProps> = React.memo(({ config, set
                         id: `${u.user_name || 'user'}-${idx}`,
                         name: u.user_name || 'Anonymous',
                         tier: String(u.user_tier).toUpperCase() === 'PREMIUM' ? 'premium' : 'support',
-                        avatar: './icons/boosty/Color_avatar.svg',
+                        avatar: u.user_profile_url_image || './icons/boosty/Color_avatar.svg',
                     }));
                     setSupporters(list);
                 } else {

--- a/src/types.ts
+++ b/src/types.ts
@@ -173,4 +173,4 @@ export interface McpLogItem {
     status: 'pending' | 'approved' | 'rejected' | 'running' | 'success' | 'failed';
 }
 
-export const VERSION = '2.6.7';
+export const VERSION = '2.6.8';


### PR DESCRIPTION
Bump version to 2.6.8 and add user_profile_url_image handling for supporters in SupportView.

---
*PR created automatically by Jules for task [17939015286699055389](https://jules.google.com/task/17939015286699055389) started by @megoRU*