### PR TITLE
Redesign TitleBar with modern full-height window controls

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -192,9 +192,9 @@ function createWindow(): void {
         titleBarOverlay: {
             color: getThemeColor(config.theme),
             symbolColor: getThemeSymbolColor(config.theme),
-            height: 30
+            height: 38
         },
-        trafficLightPosition: { x: 10, y: 8 },
+        trafficLightPosition: { x: 10, y: 11 },
         webPreferences: {
             preload: preloadPath,
             contextIsolation: true,

--- a/electron/src/ipc-handlers.ts
+++ b/electron/src/ipc-handlers.ts
@@ -265,7 +265,7 @@ export function registerIpcHandlers(getMainWindow: () => BrowserWindow | null) {
                 win.setTitleBarOverlay({
                     color: getThemeColor(config.theme),
                     symbolColor: getThemeSymbolColor(config.theme),
-                    height: 30
+                    height: 38
                 })
             } catch (err) {
                 console.error('[Window] Failed to update titleBarOverlay:', err)

--- a/src/App.css
+++ b/src/App.css
@@ -597,6 +597,47 @@ input[type=number] {
     color: var(--text-primary) !important;
 }
 
+/* Custom Window Controls (Linux / Frameless) */
+.window-controls-container {
+    display: flex;
+    align-items: center;
+    height: 100%;
+    margin-left: auto;
+    flex-shrink: 0;
+    -webkit-app-region: no-drag;
+    z-index: 10;
+}
+
+.window-control-btn {
+    width: 46px;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: none !important;
+    border-radius: 0 !important;
+    background: transparent !important;
+    color: var(--text-primary);
+    cursor: pointer;
+    padding: 0 !important;
+    transition: background-color 0.15s ease, color 0.15s ease;
+    -webkit-app-region: no-drag;
+}
+
+.window-control-btn:hover {
+    background-color: var(--hover-surface) !important;
+}
+
+.window-control-btn.close:hover {
+    background-color: #e81123 !important;
+    color: #ffffff !important;
+}
+
+.window-control-btn.close:active {
+    background-color: #f1707a !important;
+    color: #ffffff !important;
+}
+
 .header-tab:not(.active-colored):hover,
 .header-tab.always-hover:not(.active-colored) {
     background: var(--hover-surface) !important;

--- a/src/components/layout/TitleBar.tsx
+++ b/src/components/layout/TitleBar.tsx
@@ -292,7 +292,7 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                 minWidth: 0,
                 paddingLeft: isMac ? '68px' : '0'
             } as React.CSSProperties}>
-                <img src="./icons/48x48.png" style={{ width: '16px', height: '16px', marginRight: '6px' }}
+                <img src="./icons/48x48.png" style={{ width: '20px', height: '20px', marginRight: '6px' }}
                     alt="Logo" draggable="false" />
 
                 {!isOnboarding && (
@@ -301,10 +301,12 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                             className={`nav-item ${activeView === 'home' ? 'active' : ''}`}
                             onClick={() => setActiveView('home')}
                             style={{
-                                padding: '0 6px',
-                                height: '26px',
+                                width: '28px',
+                                height: '28px',
+                                padding: 0,
                                 display: 'flex',
                                 alignItems: 'center',
+                                justifyContent: 'center',
                                 borderRadius: '4px',
                                 background: 'transparent',
                                 border: 'none',
@@ -314,7 +316,7 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                                 WebkitAppRegion: 'no-drag'
                             } as React.CSSProperties}
                         >
-                            <Home size={14} />
+                            <Home size={17} />
                         </button>
 
                         {onOpenLocalTerminal && (
@@ -322,10 +324,12 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                                 className="nav-item"
                                 onClick={onOpenLocalTerminal}
                                 style={{
-                                    padding: '0 6px',
-                                    height: '26px',
+                                    width: '28px',
+                                    height: '28px',
+                                    padding: 0,
                                     display: 'flex',
                                     alignItems: 'center',
+                                    justifyContent: 'center',
                                     borderRadius: '4px',
                                     background: 'transparent',
                                     border: 'none',
@@ -335,7 +339,7 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                                     WebkitAppRegion: 'no-drag'
                                 } as React.CSSProperties}
                             >
-                                <Terminal size={14} />
+                                <Terminal size={17} />
                             </button>
                         )}
 
@@ -343,10 +347,12 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                             className={`nav-item ${activeView === 'settings' ? 'active' : ''}`}
                             onClick={() => setActiveView('settings')}
                             style={{
-                                padding: '0 6px',
-                                height: '26px',
+                                width: '28px',
+                                height: '28px',
+                                padding: 0,
                                 display: 'flex',
                                 alignItems: 'center',
+                                justifyContent: 'center',
                                 borderRadius: '4px',
                                 background: 'transparent',
                                 border: 'none',
@@ -357,7 +363,7 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                                 position: 'relative'
                             } as React.CSSProperties}
                         >
-                            <Settings size={14} />
+                            <Settings size={17} />
                             {hasUpdate && (
                                 <span style={{
                                     position: 'absolute',
@@ -385,8 +391,8 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                             className={`nav-item ${activeView === 'support' ? 'active' : ''}`}
                             onClick={() => setActiveView('support')}
                             style={{
-                                width: '26px',
-                                height: '26px',
+                                width: '28px',
+                                height: '28px',
                                 padding: 0,
                                 display: 'flex',
                                 alignItems: 'center',
@@ -400,7 +406,7 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                                 WebkitAppRegion: 'no-drag'
                             } as React.CSSProperties}
                         >
-                            <Heart size={14} fill={activeView === 'support' ? 'currentColor' : 'none'} />
+                            <Heart size={17} fill={activeView === 'support' ? 'currentColor' : 'none'} />
                         </button>
                     </>
                 )}
@@ -485,10 +491,12 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                             className="add-tab-btn"
                             onClick={() => setActiveView('home')}
                             style={{
-                                padding: '0 6px',
-                                height: '26px',
+                                width: '28px',
+                                height: '28px',
+                                padding: 0,
                                 display: 'flex',
                                 alignItems: 'center',
+                                justifyContent: 'center',
                                 borderRadius: '4px',
                                 background: 'transparent',
                                 border: 'none',
@@ -498,7 +506,7 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                                 flexShrink: 0
                             } as React.CSSProperties}
                         >
-                            <Plus size={14} />
+                            <Plus size={17} />
                         </button>
                     </div>
                 )}

--- a/src/components/layout/TitleBar.tsx
+++ b/src/components/layout/TitleBar.tsx
@@ -245,13 +245,33 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
         }
     };
 
-    const rightPadding = ipcRenderer?.platform === 'darwin'
+    const platform = ipcRenderer?.platform;
+    const isMac = platform === 'darwin';
+    const isWin = platform === 'win32';
+    const showCustomControls = !isMac && !isWin;
+
+    const [isMaximized, setIsMaximized] = React.useState(false);
+
+    React.useEffect(() => {
+        if (showCustomControls && ipcRenderer?.onWindowMaximizedState) {
+            const unsub = ipcRenderer.onWindowMaximizedState((maximized: boolean) => {
+                setIsMaximized(maximized);
+            });
+            return () => {
+                if (typeof unsub === 'function') unsub();
+            };
+        }
+    }, [showCustomControls]);
+
+    const rightPadding = isMac
         ? '8px'
-        : 'max(105px, env(titlebar-area-right, 105px))';
+        : isWin
+            ? 'calc(100vw - env(titlebar-area-right, calc(100vw - 138px)))'
+            : '0px';
 
     return (
         <div className="title-bar" style={{
-            height: '30px',
+            height: '38px',
             display: 'flex',
             alignItems: 'center',
             paddingLeft: '8px',
@@ -270,7 +290,7 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                 height: '100%',
                 flex: 1,
                 minWidth: 0,
-                paddingLeft: ipcRenderer?.platform === 'darwin' ? '68px' : '0'
+                paddingLeft: isMac ? '68px' : '0'
             } as React.CSSProperties}>
                 <img src="./icons/48x48.png" style={{ width: '16px', height: '16px', marginRight: '6px' }}
                     alt="Logo" draggable="false" />
@@ -281,8 +301,8 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                             className={`nav-item ${activeView === 'home' ? 'active' : ''}`}
                             onClick={() => setActiveView('home')}
                             style={{
-                                padding: '0 5px',
-                                height: '24px',
+                                padding: '0 6px',
+                                height: '26px',
                                 display: 'flex',
                                 alignItems: 'center',
                                 borderRadius: '4px',
@@ -302,8 +322,8 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                                 className="nav-item"
                                 onClick={onOpenLocalTerminal}
                                 style={{
-                                    padding: '0 5px',
-                                    height: '24px',
+                                    padding: '0 6px',
+                                    height: '26px',
                                     display: 'flex',
                                     alignItems: 'center',
                                     borderRadius: '4px',
@@ -323,8 +343,8 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                             className={`nav-item ${activeView === 'settings' ? 'active' : ''}`}
                             onClick={() => setActiveView('settings')}
                             style={{
-                                padding: '0 5px',
-                                height: '24px',
+                                padding: '0 6px',
+                                height: '26px',
                                 display: 'flex',
                                 alignItems: 'center',
                                 borderRadius: '4px',
@@ -365,8 +385,8 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                             className={`nav-item ${activeView === 'support' ? 'active' : ''}`}
                             onClick={() => setActiveView('support')}
                             style={{
-                                width: '24px',
-                                height: '24px',
+                                width: '26px',
+                                height: '26px',
                                 padding: 0,
                                 display: 'flex',
                                 alignItems: 'center',
@@ -388,7 +408,7 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                 <div style={{ width: '1px', height: '16px', background: 'var(--border)', margin: '0 4px', display: isOnboarding ? 'none' : 'block' }} />
 
                 {!isOnboarding && (
-                    <div style={{ display: 'flex', alignItems: 'stretch', gap: '3px', flex: 1, minWidth: 0 }}>
+                    <div style={{ display: 'flex', alignItems: 'center', gap: '3px', flex: 1, minWidth: 0, height: '100%' }}>
                         <div
                             ref={tabsContainerRef}
                             style={{ display: 'flex', alignItems: 'center', gap: '3px', overflowX: 'auto', paddingBottom: '0', WebkitAppRegion: 'no-drag' } as React.CSSProperties}
@@ -423,7 +443,7 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                                             alignItems: 'center',
                                             gap: '5px',
                                             padding: '0 6px',
-                                            height: '24px',
+                                            height: '26px',
                                             borderRadius: '4px',
                                             cursor: 'pointer',
                                             fontSize: '0.82rem',
@@ -465,8 +485,8 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                             className="add-tab-btn"
                             onClick={() => setActiveView('home')}
                             style={{
-                                padding: '0 5px',
-                                height: '24px',
+                                padding: '0 6px',
+                                height: '26px',
                                 display: 'flex',
                                 alignItems: 'center',
                                 borderRadius: '4px',
@@ -483,6 +503,44 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                     </div>
                 )}
                 {isOnboarding && <div style={{ flex: 1 }} />}
+
+                {showCustomControls && (
+                    <div className="window-controls-container">
+                        <button
+                            className="window-control-btn"
+                            onClick={() => ipcRenderer?.minimize?.()}
+                            title="Minimize"
+                        >
+                            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M1.5 6H10.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+                            </svg>
+                        </button>
+                        <button
+                            className="window-control-btn"
+                            onClick={() => ipcRenderer?.maximize?.()}
+                            title={isMaximized ? "Restore" : "Maximize"}
+                        >
+                            {isMaximized ? (
+                                <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                    <path d="M3.5 3.5V1.5H10.5V8.5H8.5M1.5 3.5H8.5V10.5H1.5V3.5Z" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
+                                </svg>
+                            ) : (
+                                <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                    <rect x="1.5" y="1.5" width="9" height="9" stroke="currentColor" strokeWidth="1.2" rx="1" />
+                                </svg>
+                            )}
+                        </button>
+                        <button
+                            className="window-control-btn close"
+                            onClick={() => ipcRenderer?.close?.()}
+                            title="Close"
+                        >
+                            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M2 2L10 10M10 2L2 10" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+                            </svg>
+                        </button>
+                    </div>
+                )}
             </div>
         </div>
     );


### PR DESCRIPTION
Redesigned the top title bar of the application to align with modern IDE standards (VS Code, IntelliJ IDEA).
1. Updated title bar height to 38px.
2. Updated Electron titleBarOverlay height to 38px on Windows with native WCO overlay calculations.
3. Centered traffic lights on macOS.
4. Added custom window controls for Linux/frameless environments with full-height buttons, standard minimize/maximize hover, and red close button hover styling.
5. Preserved draggable title bar regions, z-index layering, and dark/light theme integration.

---
*PR created automatically by Jules for task [18190831028574347318](https://jules.google.com/task/18190831028574347318) started by @megoRU*