### PR TITLE
Polish titlebar window controls and SSH tab styling

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -609,7 +609,7 @@ input[type=number] {
 }
 
 .window-control-btn {
-    width: 46px;
+    width: 49px;
     height: 100%;
     display: flex;
     align-items: center;

--- a/src/App.css
+++ b/src/App.css
@@ -589,7 +589,7 @@ input[type=number] {
 
 .nav-item.active {
     background: var(--hover-surface) !important;
-    color: var(--accent) !important;
+    color: var(--text-primary) !important;
 }
 
 .add-tab-btn:hover {

--- a/src/App.css
+++ b/src/App.css
@@ -172,7 +172,7 @@ input, select, button, textarea {
     font-family: inherit;
     font-size: inherit;
     border: 1px solid var(--border);
-    border-radius: 8px !important;
+    border-radius: 6px !important;
     font-weight: 400;
     transition: border-color 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
     line-height: inherit;

--- a/src/components/layout/TitleBar.tsx
+++ b/src/components/layout/TitleBar.tsx
@@ -285,14 +285,14 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
         } as React.CSSProperties} ref={menuRef}>
             <div style={{
                 display: 'flex',
-                gap: '2px',
+                gap: '4px',
                 alignItems: 'center',
                 height: '100%',
                 flex: 1,
                 minWidth: 0,
                 paddingLeft: isMac ? '68px' : '0'
             } as React.CSSProperties}>
-                <img src="./icons/48x48.png" style={{ width: '20px', height: '20px', marginRight: '6px' }}
+                <img src="./icons/48x48.png" style={{ width: '20px', height: '20px', marginRight: '8px' }}
                     alt="Logo" draggable="false" />
 
                 {!isOnboarding && (
@@ -316,7 +316,7 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                                 WebkitAppRegion: 'no-drag'
                             } as React.CSSProperties}
                         >
-                            <Home size={20} style={{ marginRight: '2px' }} />
+                            <Home size={20} />
                         </button>
 
                         {onOpenLocalTerminal && (
@@ -339,7 +339,7 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                                     WebkitAppRegion: 'no-drag'
                                 } as React.CSSProperties}
                             >
-                                <Terminal size={20} style={{ marginRight: '2px' }} />
+                                <Terminal size={20} />
                             </button>
                         )}
 
@@ -363,7 +363,7 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                                 position: 'relative'
                             } as React.CSSProperties}
                         >
-                            <Settings size={20} style={{ marginRight: '2px' }} />
+                            <Settings size={20} />
                             {hasUpdate && (
                                 <span style={{
                                     position: 'absolute',
@@ -406,12 +406,12 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                                 WebkitAppRegion: 'no-drag'
                             } as React.CSSProperties}
                         >
-                            <Heart size={20} fill={activeView === 'support' ? 'currentColor' : 'none'} style={{ marginRight: '2px' }} />
+                            <Heart size={20} fill={activeView === 'support' ? 'currentColor' : 'none'} />
                         </button>
                     </>
                 )}
 
-                <div style={{ width: '1px', height: '16px', background: 'var(--border)', margin: '0 4px', display: isOnboarding ? 'none' : 'block' }} />
+                <div style={{ width: '1px', height: '16px', background: 'var(--border)', margin: '0 6px', display: isOnboarding ? 'none' : 'block' }} />
 
                 {!isOnboarding && (
                     <div style={{ display: 'flex', alignItems: 'center', gap: '3px', flex: 1, minWidth: 0, height: '100%' }}>

--- a/src/components/layout/TitleBar.tsx
+++ b/src/components/layout/TitleBar.tsx
@@ -316,7 +316,7 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                                 WebkitAppRegion: 'no-drag'
                             } as React.CSSProperties}
                         >
-                            <Home size={17} />
+                            <Home size={20} />
                         </button>
 
                         {onOpenLocalTerminal && (
@@ -339,7 +339,7 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                                     WebkitAppRegion: 'no-drag'
                                 } as React.CSSProperties}
                             >
-                                <Terminal size={17} />
+                                <Terminal size={20} />
                             </button>
                         )}
 
@@ -363,7 +363,7 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                                 position: 'relative'
                             } as React.CSSProperties}
                         >
-                            <Settings size={17} />
+                            <Settings size={20} />
                             {hasUpdate && (
                                 <span style={{
                                     position: 'absolute',
@@ -406,7 +406,7 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                                 WebkitAppRegion: 'no-drag'
                             } as React.CSSProperties}
                         >
-                            <Heart size={17} fill={activeView === 'support' ? 'currentColor' : 'none'} />
+                            <Heart size={20} fill={activeView === 'support' ? 'currentColor' : 'none'} />
                         </button>
                     </>
                 )}
@@ -507,7 +507,7 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                                 flexShrink: 0
                             } as React.CSSProperties}
                         >
-                            <Plus size={17} />
+                            <Plus size={20} />
                         </button>
                     </div>
                 )}

--- a/src/components/layout/TitleBar.tsx
+++ b/src/components/layout/TitleBar.tsx
@@ -447,20 +447,20 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                                         style={{
                                             display: 'flex',
                                             alignItems: 'center',
-                                            gap: '5px',
-                                            padding: '0 6px',
+                                            gap: '6px',
+                                            padding: '0 10px',
                                             height: '26px',
                                             borderRadius: '4px',
                                             cursor: 'pointer',
                                             fontSize: '0.82rem',
-                                            fontWeight: isActive ? 600 : 400,
+                                            fontWeight: 500,
                                             background: useActiveColor ? 'var(--accent)' : (isActive || alwaysHover ? 'var(--hover-surface)' : 'transparent'),
                                             color: useActiveColor ? 'white' : (isActive ? 'var(--text-primary)' : 'var(--text-secondary)'),
                                             border: isActive ? '1px solid var(--border)' : '1px solid transparent',
                                             transition: 'background-color 0.2s, color 0.2s, border-color 0.2s, box-shadow 0.2s',
                                             whiteSpace: 'nowrap',
-                                            minWidth: '36px',
-                                            maxWidth: '150px',
+                                            minWidth: '48px',
+                                            maxWidth: '170px',
                                             flexShrink: 1,
                                             flex: '1 1 auto',
                                             boxShadow: useActiveColor ? '0 2px 8px rgba(var(--accent-rgb), 0.3)' : 'none',
@@ -479,7 +479,8 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                                             width: '12px',
                                             height: '12px',
                                             borderRadius: '3px',
-                                            opacity: 0.6
+                                            opacity: 0.6,
+                                            flexShrink: 0
                                         }}>
                                             <X size={10} strokeWidth={2.5} />
                                         </div>
@@ -519,8 +520,8 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                             onClick={() => ipcRenderer?.minimize?.()}
                             title="Minimize"
                         >
-                            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <path d="M1.5 6H10.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+                            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M4 10H16" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
                             </svg>
                         </button>
                         <button
@@ -529,12 +530,12 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                             title={isMaximized ? "Restore" : "Maximize"}
                         >
                             {isMaximized ? (
-                                <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                    <path d="M3.5 3.5V1.5H10.5V8.5H8.5M1.5 3.5H8.5V10.5H1.5V3.5Z" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
+                                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                    <path d="M6.5 6.5V4.5H15.5V13.5H13.5M4.5 6.5H13.5V15.5H4.5V6.5Z" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
                                 </svg>
                             ) : (
-                                <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                    <rect x="1.5" y="1.5" width="9" height="9" stroke="currentColor" strokeWidth="1.2" rx="1" />
+                                <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                    <rect x="4.5" y="4.5" width="11" height="11" stroke="currentColor" strokeWidth="1.2" rx="1" />
                                 </svg>
                             )}
                         </button>
@@ -543,8 +544,8 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                             onClick={() => ipcRenderer?.close?.()}
                             title="Close"
                         >
-                            <svg width="12" height="12" viewBox="0 0 12 12" fill="none" xmlns="http://www.w3.org/2000/svg">
-                                <path d="M2 2L10 10M10 2L2 10" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+                            <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
+                                <path d="M5 5L15 15M15 5L5 15" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
                             </svg>
                         </button>
                     </div>

--- a/src/components/layout/TitleBar.tsx
+++ b/src/components/layout/TitleBar.tsx
@@ -316,7 +316,7 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                                 WebkitAppRegion: 'no-drag'
                             } as React.CSSProperties}
                         >
-                            <Home size={20} />
+                            <Home size={20} style={{ marginRight: '2px' }} />
                         </button>
 
                         {onOpenLocalTerminal && (
@@ -339,7 +339,7 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                                     WebkitAppRegion: 'no-drag'
                                 } as React.CSSProperties}
                             >
-                                <Terminal size={20} />
+                                <Terminal size={20} style={{ marginRight: '2px' }} />
                             </button>
                         )}
 
@@ -363,7 +363,7 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                                 position: 'relative'
                             } as React.CSSProperties}
                         >
-                            <Settings size={20} />
+                            <Settings size={20} style={{ marginRight: '2px' }} />
                             {hasUpdate && (
                                 <span style={{
                                     position: 'absolute',
@@ -406,7 +406,7 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                                 WebkitAppRegion: 'no-drag'
                             } as React.CSSProperties}
                         >
-                            <Heart size={20} fill={activeView === 'support' ? 'currentColor' : 'none'} />
+                            <Heart size={20} fill={activeView === 'support' ? 'currentColor' : 'none'} style={{ marginRight: '2px' }} />
                         </button>
                     </>
                 )}
@@ -452,7 +452,7 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                                             height: '26px',
                                             borderRadius: '4px',
                                             cursor: 'pointer',
-                                            fontSize: '0.82rem',
+                                            fontSize: '0.95rem',
                                             fontWeight: 500,
                                             background: useActiveColor ? 'var(--accent)' : (isActive || alwaysHover ? 'var(--hover-surface)' : 'transparent'),
                                             color: useActiveColor ? 'white' : (isActive ? 'var(--text-primary)' : 'var(--text-secondary)'),
@@ -476,13 +476,13 @@ export const TitleBar: React.FC<TitleBarProps> = React.memo(({
                                             display: 'flex',
                                             alignItems: 'center',
                                             justifyContent: 'center',
-                                            width: '12px',
-                                            height: '12px',
+                                            width: '14px',
+                                            height: '14px',
                                             borderRadius: '3px',
                                             opacity: 0.6,
                                             flexShrink: 0
                                         }}>
-                                            <X size={10} strokeWidth={2.5} />
+                                            <X size={12} strokeWidth={2.5} />
                                         </div>
                                     </div>
                                 );


### PR DESCRIPTION
Final polish for titlebar and window controls: updated button dimensions to 49px with 20x20px SVG icons, and adjusted SSH tab font weight to medium (500) with increased horizontal padding for a spacious IDE-like appearance.

---
*PR created automatically by Jules for task [16750373839054327844](https://jules.google.com/task/16750373839054327844) started by @megoRU*